### PR TITLE
498779: [Xbase] No validation error for #[..] -> Set

### DIFF
--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.xtend
@@ -1097,4 +1097,35 @@ class XbaseValidationTest extends AbstractXbaseTestCase {
 		'''.expression.assertNoIssue(XbasePackage.Literals.XCASE_PART, IssueCodes.REDUNDANT_CASE)
 	}
 
+	@Test def void testSetLiteralTypeMismatchBug498779() {
+		'''
+			{
+				val java.util.Set<String> set = #[""]
+			}
+		'''.expression.assertError(XbasePackage.Literals.XLIST_LITERAL, IssueCodes.INCOMPATIBLE_TYPES)
+	}
+
+	@Test def void testListLiteralTypeMismatchBug498779() {
+		'''
+			{
+				val java.util.List<String> list = #{""}
+			}
+		'''.expression.assertError(XbasePackage.Literals.XSET_LITERAL, IssueCodes.INCOMPATIBLE_TYPES)
+	}
+
+	@Test def void testSetLiteralAssignedToCollectionBug498779() {
+		'''
+			{
+				val java.util.Collection<String> set = #{""}
+			}
+		'''.expression.assertNoErrors
+	}
+
+	@Test def void testListLiteralAssignedToCollectionBug498779() {
+		'''
+			{
+				val java.util.Collection<String> list = #[""]
+			}
+		'''.expression.assertNoErrors
+	}
 }

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.java
@@ -2582,4 +2582,76 @@ public class XbaseValidationTest extends AbstractXbaseTestCase {
       throw Exceptions.sneakyThrow(_e);
     }
   }
+  
+  @Test
+  public void testSetLiteralTypeMismatchBug498779() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("{");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("val java.util.Set<String> set = #[\"\"]");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      XExpression _expression = this.expression(_builder);
+      this._validationTestHelper.assertError(_expression, XbasePackage.Literals.XLIST_LITERAL, IssueCodes.INCOMPATIBLE_TYPES);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testListLiteralTypeMismatchBug498779() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("{");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("val java.util.List<String> list = #{\"\"}");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      XExpression _expression = this.expression(_builder);
+      this._validationTestHelper.assertError(_expression, XbasePackage.Literals.XSET_LITERAL, IssueCodes.INCOMPATIBLE_TYPES);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testSetLiteralAssignedToCollectionBug498779() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("{");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("val java.util.Collection<String> set = #{\"\"}");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      XExpression _expression = this.expression(_builder);
+      this._validationTestHelper.assertNoErrors(_expression);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testListLiteralAssignedToCollectionBug498779() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("{");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("val java.util.Collection<String> list = #[\"\"]");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      XExpression _expression = this.expression(_builder);
+      this._validationTestHelper.assertNoErrors(_expression);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
 }

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/computation/CollectionLiteralsTypeComputer.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/computation/CollectionLiteralsTypeComputer.java
@@ -242,14 +242,14 @@ public class CollectionLiteralsTypeComputer extends AbstractTypeComputer {
 		ParameterizedTypeReference result = new ParameterizedTypeReference(owner, collectionType);
 		result.addTypeArgument(elementType);
 		if (isIterableExpectation(expectedType) && !expectedType.isAssignableFrom(result)) {
-			// avoid to assign a set literal to a list and viceversa, checking the raw types
+			// avoid to assign a set literal to a list and viceversa:
+			// at least the raw types must be assignable
 			// https://bugs.eclipse.org/bugs/show_bug.cgi?id=498779
-			if (!expectedType.getRawTypeReference().isAssignableFrom(result.getRawTypeReference())) {
-				return result;
-			}
-			LightweightTypeReference expectedElementType = getElementOrComponentType(expectedType, owner);
-			if (matchesExpectation(elementType, expectedElementType)) {
-				return expectedType;
+			if (expectedType.getRawTypeReference().isAssignableFrom(result.getRawTypeReference())) {
+				LightweightTypeReference expectedElementType = getElementOrComponentType(expectedType, owner);
+				if (matchesExpectation(elementType, expectedElementType)) {
+					return expectedType;
+				}
 			}
 		}
 		return result;

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/computation/CollectionLiteralsTypeComputer.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/computation/CollectionLiteralsTypeComputer.java
@@ -242,6 +242,11 @@ public class CollectionLiteralsTypeComputer extends AbstractTypeComputer {
 		ParameterizedTypeReference result = new ParameterizedTypeReference(owner, collectionType);
 		result.addTypeArgument(elementType);
 		if (isIterableExpectation(expectedType) && !expectedType.isAssignableFrom(result)) {
+			// avoid to assign a set literal to a list and viceversa, checking the raw types
+			// https://bugs.eclipse.org/bugs/show_bug.cgi?id=498779
+			if (!expectedType.getRawTypeReference().isAssignableFrom(result.getRawTypeReference())) {
+				return result;
+			}
 			LightweightTypeReference expectedElementType = getElementOrComponentType(expectedType, owner);
 			if (matchesExpectation(elementType, expectedElementType)) {
 				return expectedType;


### PR DESCRIPTION
498779: [Xbase] No validation error for #[..] -> Set

Task-Url: https://bugs.eclipse.org/bugs/show_bug.cgi?id=498779
Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>