### PR TITLE
[492072] Optimized compiler

### DIFF
--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/compiler/CompilerTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/compiler/CompilerTest.java
@@ -30,8 +30,7 @@ public class CompilerTest extends AbstractOutputComparingCompilerTests {
 				"\n" + 
 				"try {\n" + 
 				"  Class<?> clazz = Class.forName(\"java.lang.String\");\n" + 
-				"  Class<?> _superclass = clazz.getSuperclass();\n" + 
-				"  org.eclipse.xtext.xbase.lib.InputOutput.<Class<?>>println(_superclass);\n" + 
+				"  org.eclipse.xtext.xbase.lib.InputOutput.<Class<?>>println(clazz.getSuperclass());\n" + 
 				"} catch (Throwable _e) {\n" + 
 				"  throw org.eclipse.xtext.xbase.lib.Exceptions.sneakyThrow(_e);\n" + 
 				"}", 
@@ -179,8 +178,7 @@ public class CompilerTest extends AbstractOutputComparingCompilerTests {
 		assertCompilesTo(
 				"final java.util.function.Consumer<String[]> _function = new java.util.function.Consumer<String[]>() {\n" + 
 				"  public void accept(final String[] it) {\n" + 
-				"    int _length = it.length;\n" +
-				"    org.eclipse.xtext.xbase.lib.InputOutput.<Integer>println(Integer.valueOf(_length));\n" + 
+				"    org.eclipse.xtext.xbase.lib.InputOutput.<Integer>println(Integer.valueOf(it.length));\n" + 
 				"  }\n" + 
 				"};\n" + 
 				"((Iterable<String[]>) null).forEach(_function);", 
@@ -224,8 +222,7 @@ public class CompilerTest extends AbstractOutputComparingCompilerTests {
 		assertCompilesTo(
 				"final java.util.function.Consumer<String[]> _function = new java.util.function.Consumer<String[]>() {\n" + 
 				"  public void accept(final String[] it) {\n" + 
-				"    int _length = it.length;\n" +
-				"    org.eclipse.xtext.xbase.lib.InputOutput.<Integer>println(Integer.valueOf(_length));\n" + 
+				"    org.eclipse.xtext.xbase.lib.InputOutput.<Integer>println(Integer.valueOf(it.length));\n" + 
 				"  }\n" + 
 				"};\n" + 
 				"((Iterable<String[]>) null).forEach(_function);", 

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/FeatureCallCompiler.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/FeatureCallCompiler.java
@@ -375,7 +375,8 @@ public class FeatureCallCompiler extends LiteralsCompiler {
 		if (isVariableDeclarationRequired(getFeatureCall(expr), expr, b)) {
 			return true;
 		}
-		if (expr.eContainingFeature() == XbasePackage.Literals.XMEMBER_FEATURE_CALL__MEMBER_CALL_TARGET) {
+		final EStructuralFeature eContainingFeature = expr.eContainingFeature();
+		if (eContainingFeature == XbasePackage.Literals.XMEMBER_FEATURE_CALL__MEMBER_CALL_TARGET) {
 			if (((XMemberFeatureCall) expr.eContainer()).isNullSafe()) {
 				if (expr instanceof XFeatureCall) {
 					JvmIdentifiableElement feature = ((XFeatureCall) expr).getFeature();
@@ -386,7 +387,7 @@ public class FeatureCallCompiler extends LiteralsCompiler {
 				return !b.hasName(expr);
 			}
 		}
-		if (expr.eContainingFeature() == XbasePackage.Literals.XBINARY_OPERATION__LEFT_OPERAND) {
+		if (eContainingFeature == XbasePackage.Literals.XBINARY_OPERATION__LEFT_OPERAND) {
 			XBinaryOperation binaryOperation = (XBinaryOperation) expr.eContainer();
 			if (binaryOperation.isReassignFirstArgument()) {
 				return true;
@@ -437,6 +438,10 @@ public class FeatureCallCompiler extends LiteralsCompiler {
 			JvmIdentifiableElement feature = featureCall.getFeature();
 			if (feature instanceof JvmField || feature instanceof JvmFormalParameter)
 				return false;
+			if (eContainingFeature == XbasePackage.Literals.XFEATURE_CALL__FEATURE_CALL_ARGUMENTS
+					|| eContainingFeature == XbasePackage.Literals.XASSIGNMENT__VALUE) {
+				return false;
+			}
 			return !b.hasName(feature);
 		}
 		return super.isVariableDeclarationRequired(expr, b);


### PR DESCRIPTION
Replacement for https://github.com/eclipse/xtext/pull/1043 after repository split

avoid generation of unnecessary line for getter result
see https://bugs.eclipse.org/bugs/show_bug.cgi?id=492072

Signed-off-by: Karsten Thoms karsten.thoms@itemis.de
