### PR TITLE
used linked maps when storing and loading AssociationsAdapter. Fixes #27

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.xtend
@@ -64,11 +64,11 @@ import org.eclipse.xtext.xbase.jvmmodel.JvmModelAssociator
 		]
 		val sourceToTargetMap = objIn.readObject as Map<String,Set<String>>
 		sourceToTargetMap.entrySet.forEach [
-			adapter.sourceToTargetMap.put(resource.getEObject(key), Sets.newHashSet(value.map[resource.getEObject(it)]))
+			adapter.sourceToTargetMap.put(resource.getEObject(key), Sets.newLinkedHashSet(value.map[resource.getEObject(it)]))
 		]
 		val targetToSourceMap = objIn.readObject as Map<String,Set<String>>
 		targetToSourceMap.entrySet.forEach [
-			adapter.targetToSourceMap.put(resource.getEObject(key), Sets.newHashSet(value.map[resource.getEObject(it)]))
+			adapter.targetToSourceMap.put(resource.getEObject(key), Sets.newLinkedHashSet(value.map[resource.getEObject(it)]))
 		]
 	}
 	

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageWritable.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageWritable.xtend
@@ -98,7 +98,7 @@ import java.io.IOException
 		val objOut = new ObjectOutputStream(zipOut);
 		try {
 			// logicalMap
-			val logicalMap = newHashMap()
+			val logicalMap = newLinkedHashMap()
 			for (entry : adapter.logicalContainerMap.entrySet) {
 				if (entry.key.eResource != resource) {
 					LOG.info("entry "+entry+" not from resource "+resource.URI + " but from "+entry.key.eResource?.URI)
@@ -109,23 +109,23 @@ import java.io.IOException
 			objOut.writeObject(logicalMap)
 			
 			// sourceToTarget
-			val sourceToTarget = newHashMap()
+			val sourceToTarget = newLinkedHashMap()
 			for (entry : adapter.sourceToTargetMap.entrySet) {
 				if (entry.key.eResource != resource) {
 					LOG.info("entry not from resource "+resource.URI + " but from "+entry.key.eResource?.URI)
 				} else {
-					sourceToTarget.put(entry.key.fragment, Sets.newHashSet(entry.value.map[fragment]))
+					sourceToTarget.put(entry.key.fragment, Sets.newLinkedHashSet(entry.value.map[fragment]))
 				}
 			}
 			objOut.writeObject(sourceToTarget)
 			
 			// targetToSource
-			val targetToSource = newHashMap()
+			val targetToSource = newLinkedHashMap()
 			for (entry : adapter.targetToSourceMap.entrySet) {
 				if (entry.key.eResource != resource) {
 					LOG.info("entry not from resource "+resource.URI + " but from "+entry.key.eResource?.URI)
 				} else {
-					targetToSource.put(entry.key.fragment, Sets.newHashSet(entry.value.map[fragment]))
+					targetToSource.put(entry.key.fragment, Sets.newLinkedHashSet(entry.value.map[fragment]))
 				}
 			}
 			objOut.writeObject(targetToSource)

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.java
@@ -12,7 +12,7 @@ import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -126,8 +126,8 @@ public class BatchLinkableResourceStorageLoadable extends ResourceStorageLoadabl
           return resource.getEObject(it_1);
         };
         Iterable<EObject> _map = IterableExtensions.<String, EObject>map(_value, _function_3);
-        HashSet<EObject> _newHashSet = Sets.<EObject>newHashSet(_map);
-        adapter.sourceToTargetMap.put(_eObject, _newHashSet);
+        LinkedHashSet<EObject> _newLinkedHashSet = Sets.<EObject>newLinkedHashSet(_map);
+        adapter.sourceToTargetMap.put(_eObject, _newLinkedHashSet);
       };
       _entrySet_1.forEach(_function_2);
       Object _readObject_2 = objIn.readObject();
@@ -141,8 +141,8 @@ public class BatchLinkableResourceStorageLoadable extends ResourceStorageLoadabl
           return resource.getEObject(it_1);
         };
         Iterable<EObject> _map = IterableExtensions.<String, EObject>map(_value, _function_4);
-        HashSet<EObject> _newHashSet = Sets.<EObject>newHashSet(_map);
-        adapter.targetToSourceMap.put(_eObject, _newHashSet);
+        LinkedHashSet<EObject> _newLinkedHashSet = Sets.<EObject>newLinkedHashSet(_map);
+        adapter.targetToSourceMap.put(_eObject, _newLinkedHashSet);
       };
       _entrySet_2.forEach(_function_3);
     } catch (Throwable _e) {

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageWritable.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageWritable.java
@@ -14,8 +14,8 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
@@ -135,7 +135,7 @@ public class BatchLinkableResourceStorageWritable extends ResourceStorageWritabl
     }
     final ObjectOutputStream objOut = new ObjectOutputStream(zipOut);
     try {
-      final HashMap<String, String> logicalMap = CollectionLiterals.<String, String>newHashMap();
+      final LinkedHashMap<String, String> logicalMap = CollectionLiterals.<String, String>newLinkedHashMap();
       Set<Map.Entry<EObject, JvmIdentifiableElement>> _entrySet = adapter.logicalContainerMap.entrySet();
       for (final Map.Entry<EObject, JvmIdentifiableElement> entry : _entrySet) {
         EObject _key = entry.getKey();
@@ -162,7 +162,7 @@ public class BatchLinkableResourceStorageWritable extends ResourceStorageWritabl
         }
       }
       objOut.writeObject(logicalMap);
-      final HashMap<String, HashSet<String>> sourceToTarget = CollectionLiterals.<String, HashSet<String>>newHashMap();
+      final LinkedHashMap<String, LinkedHashSet<String>> sourceToTarget = CollectionLiterals.<String, LinkedHashSet<String>>newLinkedHashMap();
       Set<Map.Entry<EObject, Set<EObject>>> _entrySet_1 = adapter.sourceToTargetMap.entrySet();
       for (final Map.Entry<EObject, Set<EObject>> entry_1 : _entrySet_1) {
         EObject _key_3 = entry_1.getKey();
@@ -188,12 +188,12 @@ public class BatchLinkableResourceStorageWritable extends ResourceStorageWritabl
             return this.getFragment(it);
           };
           Iterable<String> _map = IterableExtensions.<EObject, String>map(_value_1, _function_1);
-          HashSet<String> _newHashSet = Sets.<String>newHashSet(_map);
-          sourceToTarget.put(_fragment_2, _newHashSet);
+          LinkedHashSet<String> _newLinkedHashSet = Sets.<String>newLinkedHashSet(_map);
+          sourceToTarget.put(_fragment_2, _newLinkedHashSet);
         }
       }
       objOut.writeObject(sourceToTarget);
-      final HashMap<String, HashSet<String>> targetToSource = CollectionLiterals.<String, HashSet<String>>newHashMap();
+      final LinkedHashMap<String, LinkedHashSet<String>> targetToSource = CollectionLiterals.<String, LinkedHashSet<String>>newLinkedHashMap();
       Set<Map.Entry<EObject, Set<EObject>>> _entrySet_2 = adapter.targetToSourceMap.entrySet();
       for (final Map.Entry<EObject, Set<EObject>> entry_2 : _entrySet_2) {
         EObject _key_6 = entry_2.getKey();
@@ -219,8 +219,8 @@ public class BatchLinkableResourceStorageWritable extends ResourceStorageWritabl
             return this.getFragment(it);
           };
           Iterable<String> _map_1 = IterableExtensions.<EObject, String>map(_value_2, _function_2);
-          HashSet<String> _newHashSet_1 = Sets.<String>newHashSet(_map_1);
-          targetToSource.put(_fragment_3, _newHashSet_1);
+          LinkedHashSet<String> _newLinkedHashSet_1 = Sets.<String>newLinkedHashSet(_map_1);
+          targetToSource.put(_fragment_3, _newLinkedHashSet_1);
         }
       }
       objOut.writeObject(targetToSource);


### PR DESCRIPTION
used linked maps when storing and loading AssociationsAdapter. Fixes #27

Signed-off-by: Christian Dietrich christian.dietrich@itemis.de
