### PR TITLE
406762: check if the return is contained in a throw

### DIFF
--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/compiler/CompilerTests2.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/compiler/CompilerTests2.xtend
@@ -2042,4 +2042,55 @@ class CompilerTests2 extends AbstractOutputComparingCompilerTests {
 		''', false)
 	}
 
+	@Test def void test406762_ValidReturnInLambdaContainedInThrow() {
+		'''
+			throw {
+				val foo = [|return "foo"]
+				new Exception(foo.apply)
+			}
+		'''.compilesTo('''
+			try {
+			  Exception _xblockexpression = null;
+			  {
+			    final org.eclipse.xtext.xbase.lib.Functions.Function0<String> _function = new org.eclipse.xtext.xbase.lib.Functions.Function0<String>() {
+			      public String apply() {
+			        return "foo";
+			      }
+			    };
+			    final org.eclipse.xtext.xbase.lib.Functions.Function0<String> foo = _function;
+			    String _apply = foo.apply();
+			    _xblockexpression = new Exception(_apply);
+			  }
+			  throw _xblockexpression;
+			} catch (Throwable _e) {
+			  throw org.eclipse.xtext.xbase.lib.Exceptions.sneakyThrow(_e);
+			}
+		''')
+	}
+
+	@Test def void test406762_ValidReturnInLambdaContainedInThrow_1() {
+		'''
+			throw {
+				val ()=>Exception foo = [|return new Exception]
+				foo.apply
+			}
+		'''.compilesTo('''
+			try {
+			  Exception _xblockexpression = null;
+			  {
+			    final org.eclipse.xtext.xbase.lib.Functions.Function0<Exception> _function = new org.eclipse.xtext.xbase.lib.Functions.Function0<Exception>() {
+			      public Exception apply() {
+			        return new Exception();
+			      }
+			    };
+			    final org.eclipse.xtext.xbase.lib.Functions.Function0<? extends Exception> foo = _function;
+			    _xblockexpression = foo.apply();
+			  }
+			  throw _xblockexpression;
+			} catch (Throwable _e) {
+			  throw org.eclipse.xtext.xbase.lib.Exceptions.sneakyThrow(_e);
+			}
+		''')
+	}
+
 }

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.xtend
@@ -1246,6 +1246,24 @@ class XbaseValidationTest extends AbstractXbaseTestCase {
 			}
 		'''.expression.assertNoErrors
 	}
+
+	@Test def void test406762_ValidReturnInLambdaContainedInThrow() {
+		'''
+			throw {
+				val foo = [|return "foo"]
+				new Exception(foo.apply)
+			}
+		'''.expression.assertNoErrors
+	}
+
+	@Test def void test406762_ValidReturnInLambdaContainedInThrow_1() {
+		'''
+			throw {
+				val ()=>Exception foo = [|return new Exception]
+				foo.apply
+			}
+		'''.expression.assertNoErrors
+	}
 	
 	@Test def void testRangeLiteralInForLoopBug440006_01() {
 		'''

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/compiler/CompilerTests2.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/compiler/CompilerTests2.java
@@ -4380,4 +4380,133 @@ public class CompilerTests2 extends AbstractOutputComparingCompilerTests {
       throw Exceptions.sneakyThrow(_e);
     }
   }
+  
+  @Test
+  public void test406762_ValidReturnInLambdaContainedInThrow() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("throw {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("val foo = [|return \"foo\"]");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("new Exception(foo.apply)");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("try {");
+      _builder_1.newLine();
+      _builder_1.append("  ");
+      _builder_1.append("Exception _xblockexpression = null;");
+      _builder_1.newLine();
+      _builder_1.append("  ");
+      _builder_1.append("{");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("final org.eclipse.xtext.xbase.lib.Functions.Function0<String> _function = new org.eclipse.xtext.xbase.lib.Functions.Function0<String>() {");
+      _builder_1.newLine();
+      _builder_1.append("      ");
+      _builder_1.append("public String apply() {");
+      _builder_1.newLine();
+      _builder_1.append("        ");
+      _builder_1.append("return \"foo\";");
+      _builder_1.newLine();
+      _builder_1.append("      ");
+      _builder_1.append("}");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("};");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("final org.eclipse.xtext.xbase.lib.Functions.Function0<String> foo = _function;");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("String _apply = foo.apply();");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("_xblockexpression = new Exception(_apply);");
+      _builder_1.newLine();
+      _builder_1.append("  ");
+      _builder_1.append("}");
+      _builder_1.newLine();
+      _builder_1.append("  ");
+      _builder_1.append("throw _xblockexpression;");
+      _builder_1.newLine();
+      _builder_1.append("} catch (Throwable _e) {");
+      _builder_1.newLine();
+      _builder_1.append("  ");
+      _builder_1.append("throw org.eclipse.xtext.xbase.lib.Exceptions.sneakyThrow(_e);");
+      _builder_1.newLine();
+      _builder_1.append("}");
+      _builder_1.newLine();
+      this.compilesTo(_builder, _builder_1);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void test406762_ValidReturnInLambdaContainedInThrow_1() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("throw {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("val ()=>Exception foo = [|return new Exception]");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("foo.apply");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("try {");
+      _builder_1.newLine();
+      _builder_1.append("  ");
+      _builder_1.append("Exception _xblockexpression = null;");
+      _builder_1.newLine();
+      _builder_1.append("  ");
+      _builder_1.append("{");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("final org.eclipse.xtext.xbase.lib.Functions.Function0<Exception> _function = new org.eclipse.xtext.xbase.lib.Functions.Function0<Exception>() {");
+      _builder_1.newLine();
+      _builder_1.append("      ");
+      _builder_1.append("public Exception apply() {");
+      _builder_1.newLine();
+      _builder_1.append("        ");
+      _builder_1.append("return new Exception();");
+      _builder_1.newLine();
+      _builder_1.append("      ");
+      _builder_1.append("}");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("};");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("final org.eclipse.xtext.xbase.lib.Functions.Function0<? extends Exception> foo = _function;");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("_xblockexpression = foo.apply();");
+      _builder_1.newLine();
+      _builder_1.append("  ");
+      _builder_1.append("}");
+      _builder_1.newLine();
+      _builder_1.append("  ");
+      _builder_1.append("throw _xblockexpression;");
+      _builder_1.newLine();
+      _builder_1.append("} catch (Throwable _e) {");
+      _builder_1.newLine();
+      _builder_1.append("  ");
+      _builder_1.append("throw org.eclipse.xtext.xbase.lib.Exceptions.sneakyThrow(_e);");
+      _builder_1.newLine();
+      _builder_1.append("}");
+      _builder_1.newLine();
+      this.compilesTo(_builder, _builder_1);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
 }

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.java
@@ -2875,6 +2875,48 @@ public class XbaseValidationTest extends AbstractXbaseTestCase {
   }
   
   @Test
+  public void test406762_ValidReturnInLambdaContainedInThrow() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("throw {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("val foo = [|return \"foo\"]");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("new Exception(foo.apply)");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      XExpression _expression = this.expression(_builder);
+      this._validationTestHelper.assertNoErrors(_expression);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void test406762_ValidReturnInLambdaContainedInThrow_1() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("throw {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("val ()=>Exception foo = [|return new Exception]");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("foo.apply");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      XExpression _expression = this.expression(_builder);
+      this._validationTestHelper.assertNoErrors(_expression);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
   public void testRangeLiteralInForLoopBug440006_01() {
     try {
       StringConcatenation _builder = new StringConcatenation();

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/computation/XbaseTypeComputer.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/computation/XbaseTypeComputer.java
@@ -16,6 +16,7 @@ import java.util.Set;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.common.types.JvmDeclaredType;
 import org.eclipse.xtext.common.types.JvmEnumerationLiteral;
 import org.eclipse.xtext.common.types.JvmEnumerationType;
@@ -989,7 +990,11 @@ public class XbaseTypeComputer extends AbstractTypeComputer implements ITypeComp
 	}
 
 	protected void checkValidReturn(XReturnExpression object, ITypeComputationState state) {
-		if (hasThrowableExpectation(state)) {
+		// if the expectation comes from a method's return type
+		// then it is legal, thus we must check if the return is
+		// contained in a throw expression
+		if (hasThrowableExpectation(state) &&
+				EcoreUtil2.getContainerOfType(object, XThrowExpression.class) != null) {
 			state.addDiagnostic(new EObjectDiagnosticImpl(
 					Severity.ERROR,
 					IssueCodes.INVALID_RETURN,


### PR DESCRIPTION
It is necessary to also check that, otherwise a return inside a method
that returns a Throwable would be marked as an error.

See https://github.com/eclipse/xtext-xtend/issues/68

Task-Url: https://bugs.eclipse.org/bugs/show_bug.cgi?id=406762
Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>