### PR TITLE
Remove org.eclipse.buildship.core.prefs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 *._trace
 *.xtendbin
 .DS_Store
+org.eclipse.buildship.core.prefs

--- a/.settings/org.eclipse.buildship.core.prefs
+++ b/.settings/org.eclipse.buildship.core.prefs
@@ -1,5 +1,0 @@
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-project.path=\:

--- a/org.eclipse.xtext.builder.standalone.tests/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.builder.standalone.tests/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.builder.standalone.tests

--- a/org.eclipse.xtext.builder.standalone/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.builder.standalone/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.builder.standalone

--- a/org.eclipse.xtext.common.types.tests/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.common.types.tests/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.common.types.tests

--- a/org.eclipse.xtext.common.types/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.common.types/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.common.types

--- a/org.eclipse.xtext.ecore/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.ecore/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.ecore

--- a/org.eclipse.xtext.extras.tests/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.extras.tests/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.extras.tests

--- a/org.eclipse.xtext.generator/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.generator/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.generator

--- a/org.eclipse.xtext.java.tests/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.java.tests/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.java.tests

--- a/org.eclipse.xtext.java/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.java/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.java

--- a/org.eclipse.xtext.purexbase.tests/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.purexbase.tests/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.purexbase.tests

--- a/org.eclipse.xtext.purexbase/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.purexbase/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.purexbase

--- a/org.eclipse.xtext.smap/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.smap/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.smap

--- a/org.eclipse.xtext.xbase.ide/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.xbase.ide/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.xbase.ide

--- a/org.eclipse.xtext.xbase.testdata/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.xbase.testdata/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.xbase.testdata

--- a/org.eclipse.xtext.xbase.testing/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.xbase.testing/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.xbase.testing

--- a/org.eclipse.xtext.xbase.testlanguages/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.xbase.testlanguages/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.xbase.testlanguages

--- a/org.eclipse.xtext.xbase.tests/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.xbase.tests/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.xbase.tests

--- a/org.eclipse.xtext.xbase/.settings/org.eclipse.buildship.core.prefs
+++ b/org.eclipse.xtext.xbase/.settings/org.eclipse.buildship.core.prefs
@@ -1,7 +1,0 @@
-build.commands=org.eclipse.jdt.core.javabuilder,org.eclipse.xtext.ui.shared.xtextBuilder
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-connection.project.dir=..
-derived.resources=.gradle,build
-eclipse.preferences.version=1
-natures=org.eclipse.jdt.core.javanature,org.eclipse.xtext.ui.shared.xtextNature
-project.path=\:org.eclipse.xtext.xbase


### PR DESCRIPTION
Files are generated on Gradle project import or by Oomph setup
Ignore org.eclipse.buildship.core.prefs

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>