### PR TITLE
[eclipse/xtext#1089] Replace (not)equal operators by triple (not)equals

### DIFF
--- a/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/StandaloneBuilder.xtend
+++ b/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/StandaloneBuilder.xtend
@@ -71,7 +71,7 @@ class StandaloneBuilder {
 	@Inject IJavaCompiler compiler
 
 	def void setTempDir(String pathAsString) {
-		if (pathAsString != null) {
+		if (pathAsString !== null) {
 			tempDir = new File(pathAsString)
 		}
 	}
@@ -82,7 +82,7 @@ class StandaloneBuilder {
 	 */
 	def boolean launch() {
 		val needsJava = languages.values.exists[linksAgainstJava]
-		if (baseDir == null) {
+		if (baseDir === null) {
 			baseDir = System.getProperty('user.dir')
 			LOG.warn("Property baseDir not set. Using '" + baseDir + "'")
 		}
@@ -92,7 +92,7 @@ class StandaloneBuilder {
 
 		val resourceSet = resourceSetProvider.get
 
-		if (encoding != null) {
+		if (encoding !== null) {
 			forceDebugLog("Setting encoding.")
 			fileEncodingSetup(languages.values, encoding)
 		}
@@ -100,7 +100,7 @@ class StandaloneBuilder {
 		LOG.info("Collecting source models.")
 		val startedAt = System.currentTimeMillis
 		var rootsToTravers = classPathEntries
-		if (classPathLookUpFilter != null) {
+		if (classPathLookUpFilter !== null) {
 			LOG.info("Class path look up filter is active.")
 			val cpLookUpFilter = Pattern.compile(classPathLookUpFilter)
 			rootsToTravers = classPathEntries.filter[root|cpLookUpFilter.matcher(root).matches]
@@ -116,7 +116,7 @@ class StandaloneBuilder {
 			LOG.info("Installing type provider.")
 			installTypeProvider(allClassPathEntries, resourceSet, null)
 		}
-		val strategy = if (clusteringConfig != null) {
+		val strategy = if (clusteringConfig !== null) {
 				LOG.info("Clustering configured.")
 				new DynamicResourceClusteringPolicy => [
 					// Convert MB to byte to make it easier for the user
@@ -234,7 +234,7 @@ class StandaloneBuilder {
 	def protected generateStubs(ResourceDescriptionsData data, List<URI> sourceResourceURIs) {
 		val stubsDir = createTempDir("stubs")
 		LOG.info("Generating stubs into " + stubsDir.absolutePath)
-		if (encoding != null)
+		if (encoding !== null)
 			encodingProvider.setDefaultEncoding(encoding)
 		commonFileAccess.setOutputPath(IFileSystemAccess.DEFAULT_OUTPUT, stubsDir.absolutePath)
 		val generateStubs = sourceResourceURIs.filter[languageAccess.linksAgainstJava]
@@ -261,7 +261,7 @@ class StandaloneBuilder {
 			val fileSystemAccess = access.fileSystemAccess
 			if (isWriteStorageResources) {
 				switch it {
-					StorageAwareResource case resourceStorageFacade != null: {
+					StorageAwareResource case resourceStorageFacade !== null: {
 						resourceStorageFacade.saveResource(it, fileSystemAccess)
 					}
 				}
@@ -275,7 +275,7 @@ class StandaloneBuilder {
 		val absoluteSource = sourceDirs
 			.map[UriUtil.createFolderURI(new File(it))]
 			.findFirst [UriUtil.isPrefixOf(it, uri)]
-		if (absoluteSource == null) {
+		if (absoluteSource === null) {
 			throw new IllegalStateException(
 				'''Resource «uri» is not contained in any of the known source folders «sourceDirs».''')
 		}
@@ -297,7 +297,7 @@ class StandaloneBuilder {
 
 	private def getFileSystemAccess(LanguageAccess language) {
 		var fsa = configuredFsas.get(language)
-		if (fsa == null) {
+		if (fsa === null) {
 			fsa = language.createFileSystemAccess(new File(baseDir))
 			fsa = fsa.configureFileSystemAccess(language)
 			configuredFsas.put(language, fsa)
@@ -352,7 +352,7 @@ class StandaloneBuilder {
 		)
 		modelsFound.asMap.forEach [ uri, resource |
 			val file = new File(uri)
-			if (resource != null && !file.directory && file.name.endsWith(".jar")) {
+			if (resource !== null && !file.directory && file.name.endsWith(".jar")) {
 				registerBundle(file)
 			}
 		]
@@ -366,10 +366,10 @@ class StandaloneBuilder {
 		try {
 			jarFile = new JarFile(file);
 			val Manifest manifest = jarFile.getManifest();
-			if (manifest == null)
+			if (manifest === null)
 				return;
 			var String name = manifest.getMainAttributes().getValue("Bundle-SymbolicName");
-			if (name != null) {
+			if (name !== null) {
 				val int indexOf = name.indexOf(';');
 				if (indexOf > 0)
 					name = name.substring(0, indexOf);
@@ -385,7 +385,7 @@ class StandaloneBuilder {
 			LOG.error(file.absolutePath, e);
 		} finally {
 			try {
-				if (jarFile != null)
+				if (jarFile !== null)
 					jarFile.close();
 			} catch (IOException e) {
 				LOG.error(jarFile, e);

--- a/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/incremental/ResourceURICollector.xtend
+++ b/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/incremental/ResourceURICollector.xtend
@@ -40,7 +40,7 @@ import org.eclipse.xtext.util.internal.Log
 		val modelsFound = new PathTraverser().resolvePathes(roots.map[toFileString].toList) [ extensions.contains(fileExtension) ]
 		modelsFound.asMap.forEach [ path, resource |
 			val file = new File(path)
-			if (resource != null && !file.directory && file.name.endsWith(".jar")) {
+			if (resource !== null && !file.directory && file.name.endsWith(".jar")) {
 				registerBundle(file)
 			}
 		]
@@ -52,10 +52,10 @@ import org.eclipse.xtext.util.internal.Log
 		try {
 			jarFile = new JarFile(file);
 			val Manifest manifest = jarFile.getManifest();
-			if (manifest == null)
+			if (manifest === null)
 				return;
 			var String name = manifest.getMainAttributes().getValue("Bundle-SymbolicName");
-			if (name != null) {
+			if (name !== null) {
 				val int indexOf = name.indexOf(';');
 				if (indexOf > 0)
 					name = name.substring(0, indexOf);
@@ -70,7 +70,7 @@ import org.eclipse.xtext.util.internal.Log
 			LOG.error(file.absolutePath, e);
 		} finally {
 			try {
-				if (jarFile != null)
+				if (jarFile !== null)
 					jarFile.close();
 			} catch (IOException e) {
 				LOG.error(jarFile, e);

--- a/org.eclipse.xtext.builder.standalone/xtend-gen/org/eclipse/xtext/builder/standalone/StandaloneBuilder.java
+++ b/org.eclipse.xtext.builder.standalone/xtend-gen/org/eclipse/xtext/builder/standalone/StandaloneBuilder.java
@@ -140,8 +140,7 @@ public class StandaloneBuilder {
   private IJavaCompiler compiler;
   
   public void setTempDir(final String pathAsString) {
-    boolean _notEquals = (!Objects.equal(pathAsString, null));
-    if (_notEquals) {
+    if ((pathAsString != null)) {
       File _file = new File(pathAsString);
       this.tempDir = _file;
     }
@@ -156,8 +155,7 @@ public class StandaloneBuilder {
       return Boolean.valueOf(it.isLinksAgainstJava());
     };
     final boolean needsJava = IterableExtensions.<LanguageAccess>exists(_values, _function);
-    boolean _equals = Objects.equal(this.baseDir, null);
-    if (_equals) {
+    if ((this.baseDir == null)) {
       String _property = System.getProperty("user.dir");
       this.baseDir = _property;
       StandaloneBuilder.LOG.warn((("Property baseDir not set. Using \'" + this.baseDir) + "\'"));
@@ -166,8 +164,7 @@ public class StandaloneBuilder {
       StandaloneBuilder.LOG.info("Using common types.");
     }
     final XtextResourceSet resourceSet = this.resourceSetProvider.get();
-    boolean _notEquals = (!Objects.equal(this.encoding, null));
-    if (_notEquals) {
+    if ((this.encoding != null)) {
       this.forceDebugLog("Setting encoding.");
       Collection<LanguageAccess> _values_1 = this.languages.values();
       this.fileEncodingSetup(_values_1, this.encoding);
@@ -175,8 +172,7 @@ public class StandaloneBuilder {
     StandaloneBuilder.LOG.info("Collecting source models.");
     final long startedAt = System.currentTimeMillis();
     Iterable<String> rootsToTravers = this.classPathEntries;
-    boolean _notEquals_1 = (!Objects.equal(this.classPathLookUpFilter, null));
-    if (_notEquals_1) {
+    if ((this.classPathLookUpFilter != null)) {
       StandaloneBuilder.LOG.info("Class path look up filter is active.");
       final Pattern cpLookUpFilter = Pattern.compile(this.classPathLookUpFilter);
       final Function1<String, Boolean> _function_1 = (String root) -> {
@@ -208,8 +204,7 @@ public class StandaloneBuilder {
       this.installTypeProvider(allClassPathEntries, resourceSet, null);
     }
     IResourceClusteringPolicy _xifexpression = null;
-    boolean _notEquals_2 = (!Objects.equal(this.clusteringConfig, null));
-    if (_notEquals_2) {
+    if ((this.clusteringConfig != null)) {
       DynamicResourceClusteringPolicy _xblockexpression = null;
       {
         StandaloneBuilder.LOG.info("Clustering configured.");
@@ -377,8 +372,7 @@ public class StandaloneBuilder {
     String _absolutePath = stubsDir.getAbsolutePath();
     String _plus = ("Generating stubs into " + _absolutePath);
     StandaloneBuilder.LOG.info(_plus);
-    boolean _notEquals = (!Objects.equal(this.encoding, null));
-    if (_notEquals) {
+    if ((this.encoding != null)) {
       this.encodingProvider.setDefaultEncoding(this.encoding);
     }
     String _absolutePath_1 = stubsDir.getAbsolutePath();
@@ -431,8 +425,8 @@ public class StandaloneBuilder {
           boolean _matched = false;
           if (it instanceof StorageAwareResource) {
             IResourceStorageFacade _resourceStorageFacade = ((StorageAwareResource)it).getResourceStorageFacade();
-            boolean _notEquals = (!Objects.equal(_resourceStorageFacade, null));
-            if (_notEquals) {
+            boolean _tripleNotEquals = (_resourceStorageFacade != null);
+            if (_tripleNotEquals) {
               _matched=true;
               IResourceStorageFacade _resourceStorageFacade_1 = ((StorageAwareResource)it).getResourceStorageFacade();
               _resourceStorageFacade_1.saveResource(((StorageAwareResource)it), fileSystemAccess);
@@ -457,8 +451,7 @@ public class StandaloneBuilder {
       return Boolean.valueOf(UriUtil.isPrefixOf(it, uri));
     };
     final URI absoluteSource = IterableExtensions.<URI>findFirst(_map, _function_1);
-    boolean _equals = Objects.equal(absoluteSource, null);
-    if (_equals) {
+    if ((absoluteSource == null)) {
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("Resource ");
       _builder.append(uri, "");
@@ -481,8 +474,8 @@ public class StandaloneBuilder {
             URI _resolve = sourceFolderURI.resolve(projectBaseURI);
             sourceFolderURI = _resolve;
           }
-          boolean _equals_1 = Objects.equal(absoluteSource, sourceFolderURI);
-          if (_equals_1) {
+          boolean _equals = Objects.equal(absoluteSource, sourceFolderURI);
+          if (_equals) {
             fsa.setCurrentSource(sourceFolder);
           }
         }
@@ -494,8 +487,7 @@ public class StandaloneBuilder {
   
   private JavaIoFileSystemAccess getFileSystemAccess(final LanguageAccess language) {
     JavaIoFileSystemAccess fsa = this.configuredFsas.get(language);
-    boolean _equals = Objects.equal(fsa, null);
-    if (_equals) {
+    if ((fsa == null)) {
       File _file = new File(this.baseDir);
       JavaIoFileSystemAccess _createFileSystemAccess = language.createFileSystemAccess(_file);
       fsa = _createFileSystemAccess;
@@ -570,7 +562,7 @@ public class StandaloneBuilder {
     Map<String, Collection<URI>> _asMap = modelsFound.asMap();
     final BiConsumer<String, Collection<URI>> _function_1 = (String uri, Collection<URI> resource) -> {
       final File file = new File(uri);
-      if ((((!Objects.equal(resource, null)) && (!file.isDirectory())) && file.getName().endsWith(".jar"))) {
+      if ((((resource != null) && (!file.isDirectory())) && file.getName().endsWith(".jar"))) {
         this.registerBundle(file);
       }
     };
@@ -584,14 +576,12 @@ public class StandaloneBuilder {
       JarFile _jarFile = new JarFile(file);
       jarFile = _jarFile;
       final Manifest manifest = jarFile.getManifest();
-      boolean _equals = Objects.equal(manifest, null);
-      if (_equals) {
+      if ((manifest == null)) {
         return;
       }
       Attributes _mainAttributes = manifest.getMainAttributes();
       String name = _mainAttributes.getValue("Bundle-SymbolicName");
-      boolean _notEquals = (!Objects.equal(name, null));
-      if (_notEquals) {
+      if ((name != null)) {
         final int indexOf = name.indexOf(";");
         if ((indexOf > 0)) {
           String _substring = name.substring(0, indexOf);
@@ -625,8 +615,7 @@ public class StandaloneBuilder {
       }
     } finally {
       try {
-        boolean _notEquals_1 = (!Objects.equal(jarFile, null));
-        if (_notEquals_1) {
+        if ((jarFile != null)) {
           jarFile.close();
         }
       } catch (final Throwable _t_1) {

--- a/org.eclipse.xtext.builder.standalone/xtend-gen/org/eclipse/xtext/builder/standalone/incremental/ResourceURICollector.java
+++ b/org.eclipse.xtext.builder.standalone/xtend-gen/org/eclipse/xtext/builder/standalone/incremental/ResourceURICollector.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.builder.standalone.incremental;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
@@ -75,7 +74,7 @@ public class ResourceURICollector {
     Map<String, Collection<URI>> _asMap = modelsFound.asMap();
     final BiConsumer<String, Collection<URI>> _function_2 = (String path, Collection<URI> resource) -> {
       final File file = new File(path);
-      if ((((!Objects.equal(resource, null)) && (!file.isDirectory())) && file.getName().endsWith(".jar"))) {
+      if ((((resource != null) && (!file.isDirectory())) && file.getName().endsWith(".jar"))) {
         this.registerBundle(file);
       }
     };
@@ -90,14 +89,12 @@ public class ResourceURICollector {
       JarFile _jarFile = new JarFile(file);
       jarFile = _jarFile;
       final Manifest manifest = jarFile.getManifest();
-      boolean _equals = Objects.equal(manifest, null);
-      if (_equals) {
+      if ((manifest == null)) {
         return;
       }
       Attributes _mainAttributes = manifest.getMainAttributes();
       String name = _mainAttributes.getValue("Bundle-SymbolicName");
-      boolean _notEquals = (!Objects.equal(name, null));
-      if (_notEquals) {
+      if ((name != null)) {
         final int indexOf = name.indexOf(";");
         if ((indexOf > 0)) {
           String _substring = name.substring(0, indexOf);
@@ -132,8 +129,7 @@ public class ResourceURICollector {
       }
     } finally {
       try {
-        boolean _notEquals_1 = (!Objects.equal(jarFile, null));
-        if (_notEquals_1) {
+        if ((jarFile != null)) {
           jarFile.close();
         }
       } catch (final Throwable _t_1) {

--- a/org.eclipse.xtext.extras.tests/src/org/eclipse/xtext/resource/uriHell/URIHandlerTest.xtend
+++ b/org.eclipse.xtext.extras.tests/src/org/eclipse/xtext/resource/uriHell/URIHandlerTest.xtend
@@ -462,7 +462,7 @@ class LoadedByClasspathFromSourceFolderTest extends AbstractURIHandlerWithEcoreT
 	
 	override getPackagedReferencedURI() {
 		var url = classLoader.getResource("org/eclipse/xtext/resource/mydsl.ecore")
-		if (url == null)
+		if (url === null)
 			url = classLoader.getResource("/org/eclipse/xtext/resource/mydsl.ecore")
 		val urlAsString = url.toString
 		return URI.createURI(urlAsString)
@@ -489,7 +489,7 @@ class LoadedByClasspathFromMavenStructureTest extends AbstractURIHandlerWithEcor
 	
 	override getPackagedReferencedURI() {
 		var url = classLoader.getResource("org/eclipse/xtext/resource/mydsl.ecore")
-		if (url == null)
+		if (url === null)
 			url = classLoader.getResource("/org/eclipse/xtext/resource/mydsl.ecore")
 		val urlAsString = url.toString
 		return URI.createURI(urlAsString)
@@ -521,7 +521,7 @@ class LoadedByClasspathBothFromMavenStructureTest extends AbstractURIHandlerWith
 	
 	override getPackagedReferencedURI() {
 		var url = classLoader.getResource("org/eclipse/xtext/resource/mydsl.ecore")
-		if (url == null)
+		if (url === null)
 			url = classLoader.getResource("/org/eclipse/xtext/resource/mydsl.ecore")
 		val urlAsString = url.toString
 		return URI.createURI(urlAsString)

--- a/org.eclipse.xtext.extras.tests/xtend-gen/org/eclipse/xtext/resource/uriHell/LoadedByClasspathBothFromMavenStructureTest.java
+++ b/org.eclipse.xtext.extras.tests/xtend-gen/org/eclipse/xtext/resource/uriHell/LoadedByClasspathBothFromMavenStructureTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.resource.uriHell;
 
-import com.google.common.base.Objects;
 import java.net.URL;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.resource.uriHell.AbstractURIHandlerWithEcoreTest;
@@ -35,8 +34,7 @@ public class LoadedByClasspathBothFromMavenStructureTest extends AbstractURIHand
   @Override
   public URI getPackagedReferencedURI() {
     URL url = this.classLoader.getResource("org/eclipse/xtext/resource/mydsl.ecore");
-    boolean _equals = Objects.equal(url, null);
-    if (_equals) {
+    if ((url == null)) {
       URL _resource = this.classLoader.getResource("/org/eclipse/xtext/resource/mydsl.ecore");
       url = _resource;
     }

--- a/org.eclipse.xtext.extras.tests/xtend-gen/org/eclipse/xtext/resource/uriHell/LoadedByClasspathFromMavenStructureTest.java
+++ b/org.eclipse.xtext.extras.tests/xtend-gen/org/eclipse/xtext/resource/uriHell/LoadedByClasspathFromMavenStructureTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.resource.uriHell;
 
-import com.google.common.base.Objects;
 import java.net.URL;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.resource.uriHell.AbstractURIHandlerWithEcoreTest;
@@ -37,8 +36,7 @@ public class LoadedByClasspathFromMavenStructureTest extends AbstractURIHandlerW
   @Override
   public URI getPackagedReferencedURI() {
     URL url = this.classLoader.getResource("org/eclipse/xtext/resource/mydsl.ecore");
-    boolean _equals = Objects.equal(url, null);
-    if (_equals) {
+    if ((url == null)) {
       URL _resource = this.classLoader.getResource("/org/eclipse/xtext/resource/mydsl.ecore");
       url = _resource;
     }

--- a/org.eclipse.xtext.extras.tests/xtend-gen/org/eclipse/xtext/resource/uriHell/LoadedByClasspathFromSourceFolderTest.java
+++ b/org.eclipse.xtext.extras.tests/xtend-gen/org/eclipse/xtext/resource/uriHell/LoadedByClasspathFromSourceFolderTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.resource.uriHell;
 
-import com.google.common.base.Objects;
 import java.net.URL;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.resource.uriHell.AbstractURIHandlerWithEcoreTest;
@@ -35,8 +34,7 @@ public class LoadedByClasspathFromSourceFolderTest extends AbstractURIHandlerWit
   @Override
   public URI getPackagedReferencedURI() {
     URL url = this.classLoader.getResource("org/eclipse/xtext/resource/mydsl.ecore");
-    boolean _equals = Objects.equal(url, null);
-    if (_equals) {
+    if ((url == null)) {
       URL _resource = this.classLoader.getResource("/org/eclipse/xtext/resource/mydsl.ecore");
       url = _resource;
     }

--- a/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/adapter/Generator2AdapterSetup.xtend
+++ b/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/adapter/Generator2AdapterSetup.xtend
@@ -50,7 +50,7 @@ class Generator2AdapterSetup {
 	}
 	
 	public def getInjector() {
-		if (injector == null) {
+		if (injector === null) {
 			injector = createInjector
 		}
 		injector

--- a/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/formatting2/FormatterStubGenerator.xtend
+++ b/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/formatting2/FormatterStubGenerator.xtend
@@ -59,7 +59,7 @@ import java.util.Set
 
 	def String getStubSuperClassName() {
 		val superGrammar = grammar.nonTerminalsSuperGrammar
-		if (superGrammar != null)
+		if (superGrammar !== null)
 			return service.createGenerator(superGrammar).stubQualifiedName
 		else
 			return AbstractFormatter2.name
@@ -77,7 +77,7 @@ import java.util.Set
 		}
 		for (action : grammar.containedActions) {
 			val featureName = action.feature
-			if (featureName != null) {
+			if (featureName !== null) {
 				val type = action.type.classifier
 				if (type instanceof EClass) {
 					val feature = type.getEStructuralFeature(featureName)

--- a/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/AntlrGrammarComparator.xtend
+++ b/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/AntlrGrammarComparator.xtend
@@ -122,7 +122,7 @@ class AntlrGrammarComparator {
 	public def compareGrammars(CharSequence grammar, CharSequence grammarReference,
 			IErrorHandler errorHandler) {
 		
-		if (errorContext == null) {			
+		if (errorContext === null) {			
 			errorContext = new ErrorContext()
 		}
 		

--- a/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/XtextAntlrGeneratorComparisonFragment.xtend
+++ b/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/XtextAntlrGeneratorComparisonFragment.xtend
@@ -146,11 +146,11 @@ class XtextAntlrGeneratorComparisonFragment extends FragmentAdapter {
 		val errorHandler = createErrorHandler()
 			
 		var RuntimeException exception = null;
-		if (projectConfig.runtime?.srcGen != null) {
+		if (projectConfig.runtime?.srcGen !== null) {
 			exception = projectConfig.runtime.srcGen.loadAndCompareGrammars(Generator.SRC_GEN, errorHandler)
 		}
 		
-		if ((!failOnError || exception === null) && !skipContentAssistGrammarComparison && projectConfig.genericIde?.srcGen != null) {
+		if ((!failOnError || exception === null) && !skipContentAssistGrammarComparison && projectConfig.genericIde?.srcGen !== null) {
 			exception = projectConfig.genericIde.srcGen.loadAndCompareGrammars(Generator.SRC_GEN_IDE, errorHandler)
 		}
 		
@@ -302,7 +302,7 @@ class XtextAntlrGeneratorComparisonFragment extends FragmentAdapter {
 		//  in 'AntlrFragmentHelperEx' defined above
 		new CombinedGrammarMarker(combined).attachToEmfObject(flattened)
 		
-		if (outlet == Generator.SRC_GEN && context.output.getOutlet(Generator.SRC_GEN) != null) {
+		if (outlet == Generator.SRC_GEN && context.output.getOutlet(Generator.SRC_GEN) !== null) {
 			
 			if (combined) {
 				template = XtextAntlrGeneratorFragment.name
@@ -314,7 +314,7 @@ class XtextAntlrGeneratorComparisonFragment extends FragmentAdapter {
 			
 			XpandFacade.create(context).evaluate2(template.replaceAll("\\.", "::") + "::generate", flattened, params);
 			
-		} else if (outlet == Generator.SRC_GEN_IDE && context.output.getOutlet(Generator.SRC_GEN_IDE) != null) {
+		} else if (outlet == Generator.SRC_GEN_IDE && context.output.getOutlet(Generator.SRC_GEN_IDE) !== null) {
 			
 			if (combined) {
 				template = XtextAntlrUiGeneratorFragment.name

--- a/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/validation/ValidatorNaming.xtend
+++ b/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/validation/ValidatorNaming.xtend
@@ -36,7 +36,7 @@ class ValidatorNaming {
 	
 	def getValidatorSuperClassName(boolean isInheritImplementation) {
 		val superGrammar = grammar.nonTerminalsSuperGrammar
-		if(isInheritImplementation && superGrammar != null) 
+		if(isInheritImplementation && superGrammar !== null) 
 			superGrammar.validatorName 
 		else
 			'org.eclipse.xtext.validation.AbstractDeclarativeValidator'

--- a/org.eclipse.xtext.generator/src/org/eclipse/xtext/ui/generator/contentAssist/ContentAssistFragment.xtend
+++ b/org.eclipse.xtext.generator/src/org/eclipse/xtext/ui/generator/contentAssist/ContentAssistFragment.xtend
@@ -75,7 +75,7 @@ class ContentAssistFragment extends Xtend2GeneratorFragment implements IInheriti
 	
 	def getSuperClassName() {
 		val superGrammar = grammar.usedGrammars.head
-		if(inheritImplementation && superGrammar != null)
+		if(inheritImplementation && superGrammar !== null)
 			superGrammar.proposalProviderName
 		else
 			"org.eclipse.xtext.ui.editor.contentassist.AbstractJavaBasedContentProposalProvider"

--- a/org.eclipse.xtext.generator/src/org/eclipse/xtext/ui/generator/contentAssist/ContentAssistFragmentExtensions.xtend
+++ b/org.eclipse.xtext.generator/src/org/eclipse/xtext/ui/generator/contentAssist/ContentAssistFragmentExtensions.xtend
@@ -40,7 +40,7 @@ class ContentAssistFragmentExtensions {
 		var Set<String> toExclude = <String>newHashSet()
 
 		val superGrammar = getSuperGrammar(grammar)
-		if (superGrammar != null) {
+		if (superGrammar !== null) {
 			val superGrammarsFqFeatureNames = computeFqFeatureNamesFromSuperGrammars(grammar)
 			val thisGrammarFqFeatureNames = computeFqFeatureNames(grammar).toSet
 

--- a/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/adapter/Generator2AdapterSetup.java
+++ b/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/adapter/Generator2AdapterSetup.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.generator.adapter;
 
-import com.google.common.base.Objects;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -70,8 +69,7 @@ public class Generator2AdapterSetup {
   public Injector getInjector() {
     Injector _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(this.injector, null);
-      if (_equals) {
+      if ((this.injector == null)) {
         Injector _createInjector = this.createInjector();
         this.injector = _createInjector;
       }

--- a/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/formatting2/FormatterStubGenerator.java
+++ b/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/formatting2/FormatterStubGenerator.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.generator.formatting2;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.inject.Inject;
@@ -105,8 +104,7 @@ public class FormatterStubGenerator {
   
   public String getStubSuperClassName() {
     final Grammar superGrammar = IInheriting.Util.getNonTerminalsSuperGrammar(this.grammar);
-    boolean _notEquals = (!Objects.equal(superGrammar, null));
-    if (_notEquals) {
+    if ((superGrammar != null)) {
       FormatterStubGenerator _createGenerator = this.service.createGenerator(superGrammar);
       return _createGenerator.getStubQualifiedName();
     } else {
@@ -132,8 +130,7 @@ public class FormatterStubGenerator {
     for (final Action action : _containedActions) {
       {
         final String featureName = action.getFeature();
-        boolean _notEquals = (!Objects.equal(featureName, null));
-        if (_notEquals) {
+        if ((featureName != null)) {
           TypeRef _type = action.getType();
           final EClassifier type = _type.getClassifier();
           if ((type instanceof EClass)) {

--- a/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/parser/antlr/AntlrGrammarComparator.java
+++ b/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/parser/antlr/AntlrGrammarComparator.java
@@ -211,8 +211,7 @@ public class AntlrGrammarComparator {
    * 			and the referenced grammar (value) for logging purposes
    */
   public AntlrGrammarComparator.ErrorContext compareGrammars(final CharSequence grammar, final CharSequence grammarReference, final AntlrGrammarComparator.IErrorHandler errorHandler) {
-    boolean _equals = Objects.equal(this.errorContext, null);
-    if (_equals) {
+    if ((this.errorContext == null)) {
       AntlrGrammarComparator.ErrorContext _errorContext = new AntlrGrammarComparator.ErrorContext();
       this.errorContext = _errorContext;
     }

--- a/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/parser/antlr/XtextAntlrGeneratorComparisonFragment.java
+++ b/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/parser/antlr/XtextAntlrGeneratorComparisonFragment.java
@@ -275,8 +275,8 @@ public class XtextAntlrGeneratorComparisonFragment extends FragmentAdapter {
     if (_runtime!=null) {
       _srcGen=_runtime.getSrcGen();
     }
-    boolean _notEquals = (!Objects.equal(_srcGen, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_srcGen != null);
+    if (_tripleNotEquals) {
       IXtextProjectConfig _projectConfig_1 = this.getProjectConfig();
       IRuntimeProjectConfig _runtime_1 = _projectConfig_1.getRuntime();
       IXtextGeneratorFileSystemAccess _srcGen_1 = _runtime_1.getSrcGen();
@@ -293,8 +293,8 @@ public class XtextAntlrGeneratorComparisonFragment extends FragmentAdapter {
       if (_genericIde!=null) {
         _srcGen_2=_genericIde.getSrcGen();
       }
-      boolean _notEquals_1 = (!Objects.equal(_srcGen_2, null));
-      _and = _notEquals_1;
+      boolean _tripleNotEquals_1 = (_srcGen_2 != null);
+      _and = _tripleNotEquals_1;
     }
     if (_and) {
       IXtextProjectConfig _projectConfig_3 = this.getProjectConfig();
@@ -496,7 +496,7 @@ public class XtextAntlrGeneratorComparisonFragment extends FragmentAdapter {
     Object[] params = null;
     CombinedGrammarMarker _combinedGrammarMarker = new CombinedGrammarMarker(combined);
     _combinedGrammarMarker.attachToEmfObject(flattened);
-    if ((Objects.equal(outlet, Generator.SRC_GEN) && (!Objects.equal(context.getOutput().getOutlet(Generator.SRC_GEN), null)))) {
+    if ((Objects.equal(outlet, Generator.SRC_GEN) && (context.getOutput().getOutlet(Generator.SRC_GEN) != null))) {
       if (combined) {
         String _name = XtextAntlrGeneratorFragment.class.getName();
         template = _name;
@@ -512,7 +512,7 @@ public class XtextAntlrGeneratorComparisonFragment extends FragmentAdapter {
       final Object[] _converted_params = (Object[])params;
       _create.evaluate2(_plus, flattened, ((List<Object>)Conversions.doWrapArray(_converted_params)));
     } else {
-      if ((Objects.equal(outlet, Generator.SRC_GEN_IDE) && (!Objects.equal(context.getOutput().getOutlet(Generator.SRC_GEN_IDE), null)))) {
+      if ((Objects.equal(outlet, Generator.SRC_GEN_IDE) && (context.getOutput().getOutlet(Generator.SRC_GEN_IDE) != null))) {
         if (combined) {
           String _name_2 = XtextAntlrUiGeneratorFragment.class.getName();
           template = _name_2;

--- a/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/validation/ValidatorNaming.java
+++ b/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/validation/ValidatorNaming.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.generator.validation;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.xtend2.lib.StringConcatenation;
@@ -58,7 +57,7 @@ public class ValidatorNaming {
     {
       final Grammar superGrammar = IInheriting.Util.getNonTerminalsSuperGrammar(this.grammar);
       String _xifexpression = null;
-      if ((isInheritImplementation && (!Objects.equal(superGrammar, null)))) {
+      if ((isInheritImplementation && (superGrammar != null))) {
         _xifexpression = this.getValidatorName(superGrammar);
       } else {
         _xifexpression = "org.eclipse.xtext.validation.AbstractDeclarativeValidator";

--- a/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/ui/generator/contentAssist/ContentAssistFragment.java
+++ b/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/ui/generator/contentAssist/ContentAssistFragment.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.ui.generator.contentAssist;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Collections;
 import java.util.List;
@@ -114,7 +113,7 @@ public class ContentAssistFragment extends Xtend2GeneratorFragment implements II
       EList<Grammar> _usedGrammars = this.grammar.getUsedGrammars();
       final Grammar superGrammar = IterableExtensions.<Grammar>head(_usedGrammars);
       String _xifexpression = null;
-      if ((this.inheritImplementation && (!Objects.equal(superGrammar, null)))) {
+      if ((this.inheritImplementation && (superGrammar != null))) {
         _xifexpression = this.getProposalProviderName(superGrammar);
       } else {
         _xifexpression = "org.eclipse.xtext.ui.editor.contentassist.AbstractJavaBasedContentProposalProvider";

--- a/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/ui/generator/contentAssist/ContentAssistFragmentExtensions.java
+++ b/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/ui/generator/contentAssist/ContentAssistFragmentExtensions.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.ui.generator.contentAssist;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import java.util.HashSet;
@@ -57,8 +56,7 @@ public class ContentAssistFragmentExtensions {
   public static Set<String> getFqFeatureNamesToExclude(final Grammar grammar) {
     Set<String> toExclude = CollectionLiterals.<String>newHashSet();
     final Grammar superGrammar = ContentAssistFragmentExtensions.getSuperGrammar(grammar);
-    boolean _notEquals = (!Objects.equal(superGrammar, null));
-    if (_notEquals) {
+    if ((superGrammar != null)) {
       final Set<String> superGrammarsFqFeatureNames = ContentAssistFragmentExtensions.computeFqFeatureNamesFromSuperGrammars(grammar);
       Iterable<String> _computeFqFeatureNames = ContentAssistFragmentExtensions.computeFqFeatureNames(grammar);
       final Set<String> thisGrammarFqFeatureNames = IterableExtensions.<String>toSet(_computeFqFeatureNames);

--- a/org.eclipse.xtext.java.tests/src/org/eclipse/xtext/java/tests/JavaInjectorProvider.xtend
+++ b/org.eclipse.xtext.java.tests/src/org/eclipse/xtext/java/tests/JavaInjectorProvider.xtend
@@ -11,7 +11,7 @@ class JavaInjectorProvider implements IInjectorProvider, IRegistryConfigurator {
 	Injector injector
 	
 	override getInjector() {
-		if (injector == null) {
+		if (injector === null) {
 			this.injector = setup.createInjector
 		}
 		return injector

--- a/org.eclipse.xtext.java.tests/src/org/eclipse/xtext/java/tests/ReusedTypeProviderTest.xtend
+++ b/org.eclipse.xtext.java.tests/src/org/eclipse/xtext/java/tests/ReusedTypeProviderTest.xtend
@@ -52,7 +52,7 @@ class ReusedTypeProviderTest extends AbstractTypeProviderTest {
 		try {
 			var String line = null;
 			val List<String> result = Lists.newArrayList();
-			while( (line = reader.readLine()) != null) {
+			while( (line = reader.readLine()) !== null) {
 				result.add(line);
 			}
 			return result;
@@ -63,7 +63,7 @@ class ReusedTypeProviderTest extends AbstractTypeProviderTest {
 	
 	override setUp() throws Exception {
 		super.setUp()
-		if (typeProvider == null) {
+		if (typeProvider === null) {
 			val pathToSources = "/org/eclipse/xtext/common/types/testSetups";
 			val files = readResource(pathToSources + "/files.list")
 			val part = new ResourceDescriptionsData(emptySet)

--- a/org.eclipse.xtext.java.tests/xtend-gen/org/eclipse/xtext/java/tests/JavaInjectorProvider.java
+++ b/org.eclipse.xtext.java.tests/xtend-gen/org/eclipse/xtext/java/tests/JavaInjectorProvider.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.java.tests;
 
-import com.google.common.base.Objects;
 import com.google.inject.Injector;
 import org.eclipse.xtext.java.JavaSourceLanguageSetup;
 import org.eclipse.xtext.testing.IInjectorProvider;
@@ -14,8 +13,7 @@ public class JavaInjectorProvider implements IInjectorProvider, IRegistryConfigu
   
   @Override
   public Injector getInjector() {
-    boolean _equals = Objects.equal(this.injector, null);
-    if (_equals) {
+    if ((this.injector == null)) {
       Injector _createInjector = this.setup.createInjector();
       this.injector = _createInjector;
     }

--- a/org.eclipse.xtext.java.tests/xtend-gen/org/eclipse/xtext/java/tests/ReusedTypeProviderTest.java
+++ b/org.eclipse.xtext.java.tests/xtend-gen/org/eclipse/xtext/java/tests/ReusedTypeProviderTest.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.java.tests;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
@@ -75,7 +74,7 @@ public class ReusedTypeProviderTest extends AbstractTypeProviderTest {
     try {
       String line = null;
       final List<String> result = Lists.<String>newArrayList();
-      while ((!Objects.equal((line = reader.readLine()), null))) {
+      while (((line = reader.readLine()) != null)) {
         result.add(line);
       }
       return result;
@@ -87,8 +86,7 @@ public class ReusedTypeProviderTest extends AbstractTypeProviderTest {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    boolean _equals = Objects.equal(ReusedTypeProviderTest.typeProvider, null);
-    if (_equals) {
+    if ((ReusedTypeProviderTest.typeProvider == null)) {
       final String pathToSources = "/org/eclipse/xtext/common/types/testSetups";
       final List<String> files = ReusedTypeProviderTest.readResource((pathToSources + "/files.list"));
       Set<IResourceDescription> _emptySet = CollectionLiterals.<IResourceDescription>emptySet();

--- a/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/InMemoryClassLoader.xtend
+++ b/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/InMemoryClassLoader.xtend
@@ -28,7 +28,7 @@ class InMemoryClassLoader extends ClassLoader {
 		if (path.endsWith(".class")) {
 			val className = pathToClassName(path)
 			val bytes = classMap.get(className)
-			if (bytes != null) {
+			if (bytes !== null) {
 				return new URL("in-memory", null, -1, path, [
 					new URLConnection(it) {
 						override void connect() {}

--- a/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/IndexAwareNameEnvironment.xtend
+++ b/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/IndexAwareNameEnvironment.xtend
@@ -35,14 +35,14 @@ import org.eclipse.xtext.resource.IResourceDescriptions
 		}
 		val candidate = resourceDescriptions.getExportedObjects(TypesPackage.Literals.JVM_DECLARED_TYPE, className, false).head
 		var NameEnvironmentAnswer result = null 
-		if (candidate != null) {
+		if (candidate !== null) {
 			val resourceDescription = resourceDescriptions.getResourceDescription(candidate.EObjectURI.trimFragment)
 			val source = stubGenerator.getJavaStubSource(candidate, resourceDescription)
 			result = new NameEnvironmentAnswer(new CompilationUnit(source.toCharArray, className.toString('/')+'.java', null), null)
 		} else {
 			val fileName = className.toString('/') + ".class"
 			val url = classLoader.getResource(fileName)
-			if (url == null) {
+			if (url === null) {
 				cache.put(className, null)
 				return null;
 			}

--- a/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.xtend
+++ b/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.xtend
@@ -53,7 +53,7 @@ class JavaDerivedStateComputer {
 				new DefaultProblemFactory()), true)
 		val compilationResult = new CompilationResult(compilationUnit, 0, 1, -1)
 		val result = parser.dietParse(compilationUnit, compilationResult)
-		if (result.types != null) {
+		if (result.types !== null) {
 			for (type : result.types) {
 				val packageName = result.currentPackage?.importName?.map[String.valueOf(it)]?.join('.')
 				val jvmType = createType(type, packageName)
@@ -80,7 +80,7 @@ class JavaDerivedStateComputer {
 		jvmType.packageName = packageName
 		jvmType.simpleName = String.valueOf(type.name)
 		if (jvmType instanceof JvmGenericType) {
-			if (type.typeParameters != null) {
+			if (type.typeParameters !== null) {
 				for (typeParam : type.typeParameters) {
 					val jvmTypeParam = TypesFactory.eINSTANCE.createJvmTypeParameter
 					jvmTypeParam.name = String.valueOf(typeParam.name)
@@ -88,7 +88,7 @@ class JavaDerivedStateComputer {
 				}
 			}
 		}
-		if (type.memberTypes != null) {
+		if (type.memberTypes !== null) {
 			for (nestedType : type.memberTypes) {
 				val nested = createType(nestedType, null)
 				jvmType.members += nested
@@ -108,7 +108,7 @@ class JavaDerivedStateComputer {
 		val classLoader = getClassLoader(resource)
 		
 		val data = resourceDescriptionsProvider.getResourceDescriptions(resource.resourceSet)
-		if (data == null)
+		if (data === null)
 			throw new IllegalStateException("no index installed")
 		// TODO use container manager
 		val nameEnv = new IndexAwareNameEnvironment(classLoader, data, stubGenerator)

--- a/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaResource.xtend
+++ b/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaResource.xtend
@@ -57,7 +57,7 @@ class JavaResource extends ResourceImpl implements IJavaSchemeUriResolver, ISync
 	}
 	
 	protected def getEncoding(URI uri, Map<?, ?> options) {
-		if (options != null) {
+		if (options !== null) {
 			val encodingOption = options.get(OPTION_ENCODING);
 			if (encodingOption instanceof String) {
 				return encodingOption;
@@ -122,10 +122,10 @@ class JavaResource extends ResourceImpl implements IJavaSchemeUriResolver, ISync
 	
 	override resolveJavaObjectURIProxy(InternalEObject proxy, JvmTypeReference sender) {
 		val access = getIndexJvmTypeAccess();
-		if (access != null) {
+		if (access !== null) {
 			try {
 				val result = access.getIndexedJvmType(proxy.eProxyURI(), getResourceSet());
-				if (result != null) {
+				if (result !== null) {
 					return result;
 				}
 			} catch(UnknownNestedTypeException e) {
@@ -137,7 +137,7 @@ class JavaResource extends ResourceImpl implements IJavaSchemeUriResolver, ISync
 	
 	IndexedJvmTypeAccess _access
 	def IndexedJvmTypeAccess getIndexJvmTypeAccess() {
-		if (_access == null) {
+		if (_access === null) {
 			val provider = resourceSet.getResourceFactoryRegistry().getProtocolToFactoryMap().get(URIHelperConstants.PROTOCOL)
 			if (provider instanceof AbstractJvmTypeProvider) {
 				_access = provider.indexedJvmTypeAccess

--- a/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/InMemoryClassLoader.java
+++ b/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/InMemoryClassLoader.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.java.resource;
 
-import com.google.common.base.Objects;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,8 +36,7 @@ public class InMemoryClassLoader extends ClassLoader {
       if (_endsWith) {
         final String className = this.pathToClassName(path);
         final byte[] bytes = this.classMap.get(className);
-        boolean _notEquals = (!Objects.equal(bytes, null));
-        if (_notEquals) {
+        if ((bytes != null)) {
           final URLStreamHandler _function = new URLStreamHandler() {
             @Override
             protected URLConnection openConnection(final URL it) throws IOException {

--- a/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/IndexAwareNameEnvironment.java
+++ b/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/IndexAwareNameEnvironment.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.java.resource;
 
-import com.google.common.base.Objects;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
@@ -60,8 +59,7 @@ public class IndexAwareNameEnvironment implements INameEnvironment {
       Iterable<IEObjectDescription> _exportedObjects = this.resourceDescriptions.getExportedObjects(TypesPackage.Literals.JVM_DECLARED_TYPE, className, false);
       final IEObjectDescription candidate = IterableExtensions.<IEObjectDescription>head(_exportedObjects);
       NameEnvironmentAnswer result = null;
-      boolean _notEquals = (!Objects.equal(candidate, null));
-      if (_notEquals) {
+      if ((candidate != null)) {
         URI _eObjectURI = candidate.getEObjectURI();
         URI _trimFragment = _eObjectURI.trimFragment();
         final IResourceDescription resourceDescription = this.resourceDescriptions.getResourceDescription(_trimFragment);
@@ -76,8 +74,7 @@ public class IndexAwareNameEnvironment implements INameEnvironment {
         String _string_1 = className.toString("/");
         final String fileName = (_string_1 + ".class");
         final URL url = this.classLoader.getResource(fileName);
-        boolean _equals = Objects.equal(url, null);
-        if (_equals) {
+        if ((url == null)) {
           this.cache.put(className, null);
           return null;
         }

--- a/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.java
+++ b/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.java
@@ -90,8 +90,7 @@ public class JavaDerivedStateComputer {
     final Parser parser = new Parser(_problemReporter, true);
     final CompilationResult compilationResult = new CompilationResult(compilationUnit, 0, 1, (-1));
     final CompilationUnitDeclaration result = parser.dietParse(compilationUnit, compilationResult);
-    boolean _notEquals = (!Objects.equal(result.types, null));
-    if (_notEquals) {
+    if ((result.types != null)) {
       for (final TypeDeclaration type : result.types) {
         {
           ImportReference _currentPackage = result.currentPackage;
@@ -149,8 +148,7 @@ public class JavaDerivedStateComputer {
     String _valueOf = String.valueOf(type.name);
     jvmType.setSimpleName(_valueOf);
     if ((jvmType instanceof JvmGenericType)) {
-      boolean _notEquals = (!Objects.equal(type.typeParameters, null));
-      if (_notEquals) {
+      if ((type.typeParameters != null)) {
         for (final TypeParameter typeParam : type.typeParameters) {
           {
             final JvmTypeParameter jvmTypeParam = TypesFactory.eINSTANCE.createJvmTypeParameter();
@@ -162,8 +160,7 @@ public class JavaDerivedStateComputer {
         }
       }
     }
-    boolean _notEquals_1 = (!Objects.equal(type.memberTypes, null));
-    if (_notEquals_1) {
+    if ((type.memberTypes != null)) {
       for (final TypeDeclaration nestedType : type.memberTypes) {
         {
           final JvmDeclaredType nested = this.createType(nestedType, null);
@@ -188,16 +185,15 @@ public class JavaDerivedStateComputer {
     final ClassLoader classLoader = this.getClassLoader(resource);
     ResourceSet _resourceSet = resource.getResourceSet();
     final IResourceDescriptions data = this.resourceDescriptionsProvider.getResourceDescriptions(_resourceSet);
-    boolean _equals = Objects.equal(data, null);
-    if (_equals) {
+    if ((data == null)) {
       throw new IllegalStateException("no index installed");
     }
     final IndexAwareNameEnvironment nameEnv = new IndexAwareNameEnvironment(classLoader, data, this.stubGenerator);
     IErrorHandlingPolicy _proceedWithAllProblems = DefaultErrorHandlingPolicies.proceedWithAllProblems();
     CompilerOptions _compilerOptions = this.getCompilerOptions(resource);
     final ICompilerRequestor _function = (CompilationResult it) -> {
-      boolean _equals_1 = Arrays.equals(it.fileName, compilationUnit.fileName);
-      if (_equals_1) {
+      boolean _equals = Arrays.equals(it.fileName, compilationUnit.fileName);
+      if (_equals) {
         final HashMap<String, byte[]> map = CollectionLiterals.<String, byte[]>newHashMap();
         List<String> topLevelTypes = CollectionLiterals.<String>newArrayList();
         ClassFile[] _classFiles = it.getClassFiles();

--- a/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/JavaResource.java
+++ b/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/JavaResource.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.java.resource;
 
-import com.google.common.base.Objects;
 import com.google.common.io.CharStreams;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -78,8 +77,7 @@ public class JavaResource extends ResourceImpl implements IJavaSchemeUriResolver
   }
   
   protected String getEncoding(final URI uri, final Map<?, ?> options) {
-    boolean _notEquals = (!Objects.equal(options, null));
-    if (_notEquals) {
+    if ((options != null)) {
       final Object encodingOption = options.get(JavaResource.OPTION_ENCODING);
       if ((encodingOption instanceof String)) {
         return ((String)encodingOption);
@@ -155,14 +153,12 @@ public class JavaResource extends ResourceImpl implements IJavaSchemeUriResolver
   @Override
   public EObject resolveJavaObjectURIProxy(final InternalEObject proxy, final JvmTypeReference sender) {
     final IndexedJvmTypeAccess access = this.getIndexJvmTypeAccess();
-    boolean _notEquals = (!Objects.equal(access, null));
-    if (_notEquals) {
+    if ((access != null)) {
       try {
         URI _eProxyURI = proxy.eProxyURI();
         ResourceSet _resourceSet = this.getResourceSet();
         final EObject result = access.getIndexedJvmType(_eProxyURI, _resourceSet);
-        boolean _notEquals_1 = (!Objects.equal(result, null));
-        if (_notEquals_1) {
+        if ((result != null)) {
           return result;
         }
       } catch (final Throwable _t) {
@@ -180,8 +176,7 @@ public class JavaResource extends ResourceImpl implements IJavaSchemeUriResolver
   private IndexedJvmTypeAccess _access;
   
   public IndexedJvmTypeAccess getIndexJvmTypeAccess() {
-    boolean _equals = Objects.equal(this._access, null);
-    if (_equals) {
+    if ((this._access == null)) {
       Resource.Factory.Registry _resourceFactoryRegistry = this.resourceSet.getResourceFactoryRegistry();
       Map<String, Object> _protocolToFactoryMap = _resourceFactoryRegistry.getProtocolToFactoryMap();
       final Object provider = _protocolToFactoryMap.get(URIHelperConstants.PROTOCOL);

--- a/org.eclipse.xtext.xbase.ide/src/org/eclipse/xtext/xbase/ide/contentassist/ClasspathBasedIdeTypesProposalProvider.xtend
+++ b/org.eclipse.xtext.xbase.ide/src/org/eclipse/xtext/xbase/ide/contentassist/ClasspathBasedIdeTypesProposalProvider.xtend
@@ -76,7 +76,7 @@ class ClasspathBasedIdeTypesProposalProvider implements IIdeTypesProposalProvide
 		val resourceSet = context.resource.resourceSet
 		if (resourceSet instanceof XtextResourceSet) {
 			val ctx = resourceSet.classpathURIContext
-			if (ctx != null) {
+			if (ctx !== null) {
 		        if (ctx instanceof Class<?>)
 		            return ctx.classLoader
 		        if (ctx instanceof ClassLoader)

--- a/org.eclipse.xtext.xbase.ide/src/org/eclipse/xtext/xbase/ide/contentassist/XbaseIdeCrossrefProposalProvider.xtend
+++ b/org.eclipse.xtext.xbase.ide/src/org/eclipse/xtext/xbase/ide/contentassist/XbaseIdeCrossrefProposalProvider.xtend
@@ -164,7 +164,7 @@ class XbaseIdeCrossrefProposalProvider extends IdeCrossrefProposalProvider {
 				labelBuilder.append(')')
 			}
 			val returnType = feature.returnType
-			if (returnType != null && returnType.simpleName != null) {
+			if (returnType !== null && returnType.simpleName !== null) {
 				labelBuilder.append(' : ')
 				labelBuilder.append(converter.toLightweightReference(returnType).humanReadableName)
 			}
@@ -176,9 +176,9 @@ class XbaseIdeCrossrefProposalProvider extends IdeCrossrefProposalProvider {
 			}
 		} else if (feature instanceof JvmField) {
 			labelBuilder.append(' : ')
-			if (feature.type != null) {
+			if (feature.type !== null) {
 				val fieldType = converter.toLightweightReference(feature.type).humanReadableName
-				if (fieldType != null)
+				if (fieldType !== null)
 					labelBuilder.append(fieldType)
 			}
 			descriptionBuilder.append(converter.toPlainTypeReference(feature.declaringType).humanReadableName)
@@ -216,9 +216,9 @@ class XbaseIdeCrossrefProposalProvider extends IdeCrossrefProposalProvider {
 				result.append(ownedConverter.toLightweightReference(parameterType.componentType).humanReadableName)
 				result.append('...')
 			} else {
-				if (parameter.parameterType != null) {
+				if (parameter.parameterType !== null) {
 					val simpleName = ownedConverter.toLightweightReference(parameter.parameterType).humanReadableName
-					if (simpleName != null)
+					if (simpleName !== null)
 						result.append(simpleName)
 				}
 			}

--- a/org.eclipse.xtext.xbase.ide/src/org/eclipse/xtext/xbase/ide/types/ClasspathScanner.xtend
+++ b/org.eclipse.xtext.xbase.ide/src/org/eclipse/xtext/xbase/ide/types/ClasspathScanner.xtend
@@ -119,7 +119,7 @@ class ClasspathScanner {
 	protected def void loadDirectoryDescriptors(File directory, String packageName, List<ITypeDescriptor> descriptors,
 			Collection<String> packagePrefixes) {
 		val children = directory.listFiles
-		if(children == null) {
+		if(children === null) {
 			return
 		}
 		for (file : children) {

--- a/org.eclipse.xtext.xbase.ide/xtend-gen/org/eclipse/xtext/xbase/ide/contentassist/ClasspathBasedIdeTypesProposalProvider.java
+++ b/org.eclipse.xtext.xbase.ide/xtend-gen/org/eclipse/xtext/xbase/ide/contentassist/ClasspathBasedIdeTypesProposalProvider.java
@@ -111,8 +111,7 @@ public class ClasspathBasedIdeTypesProposalProvider implements IIdeTypesProposal
     final ResourceSet resourceSet = _resource.getResourceSet();
     if ((resourceSet instanceof XtextResourceSet)) {
       final Object ctx = ((XtextResourceSet)resourceSet).getClasspathURIContext();
-      boolean _notEquals = (!Objects.equal(ctx, null));
-      if (_notEquals) {
+      if ((ctx != null)) {
         if ((ctx instanceof Class<?>)) {
           return ((Class<?>)ctx).getClassLoader();
         }

--- a/org.eclipse.xtext.xbase.ide/xtend-gen/org/eclipse/xtext/xbase/ide/contentassist/XbaseIdeCrossrefProposalProvider.java
+++ b/org.eclipse.xtext.xbase.ide/xtend-gen/org/eclipse/xtext/xbase/ide/contentassist/XbaseIdeCrossrefProposalProvider.java
@@ -242,7 +242,7 @@ public class XbaseIdeCrossrefProposalProvider extends IdeCrossrefProposalProvide
         labelBuilder.append(")");
       }
       final JvmTypeReference returnType = ((JvmOperation)feature).getReturnType();
-      if (((!Objects.equal(returnType, null)) && (!Objects.equal(returnType.getSimpleName(), null)))) {
+      if (((returnType != null) && (returnType.getSimpleName() != null))) {
         labelBuilder.append(" : ");
         LightweightTypeReference _lightweightReference = converter.toLightweightReference(returnType);
         String _humanReadableName = _lightweightReference.getHumanReadableName();
@@ -262,13 +262,12 @@ public class XbaseIdeCrossrefProposalProvider extends IdeCrossrefProposalProvide
       if ((feature instanceof JvmField)) {
         labelBuilder.append(" : ");
         JvmTypeReference _type = ((JvmField)feature).getType();
-        boolean _notEquals = (!Objects.equal(_type, null));
-        if (_notEquals) {
+        boolean _tripleNotEquals = (_type != null);
+        if (_tripleNotEquals) {
           JvmTypeReference _type_1 = ((JvmField)feature).getType();
           LightweightTypeReference _lightweightReference_1 = converter.toLightweightReference(_type_1);
           final String fieldType = _lightweightReference_1.getHumanReadableName();
-          boolean _notEquals_1 = (!Objects.equal(fieldType, null));
-          if (_notEquals_1) {
+          if ((fieldType != null)) {
             labelBuilder.append(fieldType);
           }
         }
@@ -328,13 +327,12 @@ public class XbaseIdeCrossrefProposalProvider extends IdeCrossrefProposalProvide
           result.append("...");
         } else {
           JvmTypeReference _parameterType_1 = parameter.getParameterType();
-          boolean _notEquals = (!Objects.equal(_parameterType_1, null));
-          if (_notEquals) {
+          boolean _tripleNotEquals = (_parameterType_1 != null);
+          if (_tripleNotEquals) {
             JvmTypeReference _parameterType_2 = parameter.getParameterType();
             LightweightTypeReference _lightweightReference_1 = ownedConverter.toLightweightReference(_parameterType_2);
             final String simpleName = _lightweightReference_1.getHumanReadableName();
-            boolean _notEquals_1 = (!Objects.equal(simpleName, null));
-            if (_notEquals_1) {
+            if ((simpleName != null)) {
               result.append(simpleName);
             }
           }

--- a/org.eclipse.xtext.xbase.ide/xtend-gen/org/eclipse/xtext/xbase/ide/types/ClasspathScanner.java
+++ b/org.eclipse.xtext.xbase.ide/xtend-gen/org/eclipse/xtext/xbase/ide/types/ClasspathScanner.java
@@ -182,8 +182,7 @@ public class ClasspathScanner {
   
   protected void loadDirectoryDescriptors(final File directory, final String packageName, final List<ITypeDescriptor> descriptors, final Collection<String> packagePrefixes) {
     final File[] children = directory.listFiles();
-    boolean _equals = Objects.equal(children, null);
-    if (_equals) {
+    if ((children == null)) {
       return;
     }
     for (final File file : children) {

--- a/org.eclipse.xtext.xbase.testing/src/org/eclipse/xtext/xbase/testing/InMemoryJavaCompiler.xtend
+++ b/org.eclipse.xtext.xbase.testing/src/org/eclipse/xtext/xbase/testing/InMemoryJavaCompiler.xtend
@@ -53,7 +53,7 @@ class InMemoryJavaCompiler {
 				return cache.get(fileName)
 			}
 			val url = classLoader.getResource(fileName)
-			if (url == null) {
+			if (url === null) {
 				cache.put(fileName, null)
 				return null;
 			}
@@ -69,7 +69,7 @@ class InMemoryJavaCompiler {
 				return cache.get(fileName)
 			}
 			val url = classLoader.getResource(fileName)
-			if (url == null) {
+			if (url === null) {
 				cache.put(fileName, null)
 				return null;
 			}
@@ -106,7 +106,7 @@ class InMemoryJavaCompiler {
 			if (path.endsWith(".class")) {
 				val className = path.substring(0, path.length-6).replace("/", ".")
 				val bytes = classMap.get(className)
-				if (bytes != null) {
+				if (bytes !== null) {
 					return new URL("in-memory", null, -1, path, [ 
 						new URLConnection(it) {
 							override void connect() {}

--- a/org.eclipse.xtext.xbase.testing/xtend-gen/org/eclipse/xtext/xbase/testing/InMemoryJavaCompiler.java
+++ b/org.eclipse.xtext.xbase.testing/xtend-gen/org/eclipse/xtext/xbase/testing/InMemoryJavaCompiler.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.testing;
 
-import com.google.common.base.Objects;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -75,8 +74,7 @@ public class InMemoryJavaCompiler {
           return this.cache.get(fileName);
         }
         final URL url = this.classLoader.getResource(fileName);
-        boolean _equals = Objects.equal(url, null);
-        if (_equals) {
+        if ((url == null)) {
           this.cache.put(fileName, null);
           return null;
         }
@@ -107,8 +105,7 @@ public class InMemoryJavaCompiler {
           return this.cache.get(fileName);
         }
         final URL url = this.classLoader.getResource(fileName);
-        boolean _equals = Objects.equal(url, null);
-        if (_equals) {
+        if ((url == null)) {
           this.cache.put(fileName, null);
           return null;
         }
@@ -163,8 +160,7 @@ public class InMemoryJavaCompiler {
           String _substring = path.substring(0, _minus);
           final String className = _substring.replace("/", ".");
           final byte[] bytes = this.classMap.get(className);
-          boolean _notEquals = (!Objects.equal(bytes, null));
-          if (_notEquals) {
+          if ((bytes != null)) {
             final URLStreamHandler _function = new URLStreamHandler() {
               @Override
               protected URLConnection openConnection(final URL it) throws IOException {

--- a/org.eclipse.xtext.xbase.tests/longrunning/src/org/eclipse/xtext/xbase/tests/typesystem/ValidatingTypeComputation.xtend
+++ b/org.eclipse.xtext.xbase.tests/longrunning/src/org/eclipse/xtext/xbase/tests/typesystem/ValidatingTypeComputation.xtend
@@ -79,13 +79,13 @@ class ValidatingRootResolvedTypes extends RootResolvedTypes {
 	}
 	
 	override reassignType(JvmIdentifiableElement identifiable, LightweightTypeReference reference) {
-		if (reference != null && !reference.isOwnedBy(getReferenceOwner()))
+		if (reference !== null && !reference.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("reference is not owned by this resolved types")
 		super.reassignType(identifiable, reference)
 	}
 	
 	override acceptHint(Object handle, LightweightBoundTypeArgument boundTypeArgument) {
-		if (boundTypeArgument.typeReference != null && !boundTypeArgument.typeReference.isOwnedBy(getReferenceOwner()))
+		if (boundTypeArgument.typeReference !== null && !boundTypeArgument.typeReference.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("reference is not owned by this resolved types")
 		super.acceptHint(handle, boundTypeArgument)
 	}
@@ -93,7 +93,7 @@ class ValidatingRootResolvedTypes extends RootResolvedTypes {
 	override protected getHints(Object handle) {
 		val result = super.getHints(handle)
 		result.forEach[ 
-			if (typeReference != null && !typeReference.isOwnedBy(referenceOwner))
+			if (typeReference !== null && !typeReference.isOwnedBy(referenceOwner))
 				throw new IllegalArgumentException("reference is not owned by this resolved types")
 		]
 		return result
@@ -110,7 +110,7 @@ class ValidatingRootResolvedTypes extends RootResolvedTypes {
 	override getAllHints(Object handle) {
 		val result = super.getAllHints(handle)
 		result.forEach [
-			if (typeReference != null &&!typeReference.isOwnedBy(getReferenceOwner()))
+			if (typeReference !== null &&!typeReference.isOwnedBy(getReferenceOwner()))
 				throw new IllegalArgumentException("hint is not owned by this resolved types")
 		]
 		return result
@@ -132,14 +132,14 @@ class ValidatingRootResolvedTypes extends RootResolvedTypes {
 	
 	override getActualType(XExpression expression) {
 		val result = super.getActualType(expression)
-		if (result != null && !result.isOwnedBy(getReferenceOwner()))
+		if (result !== null && !result.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("result is not owned by this resolved types")
 		return result
 	}
 	
 	override getExpectedType(XExpression expression) {
 		val result = super.getExpectedType(expression)
-		if (result != null && !result.isOwnedBy(getReferenceOwner()))
+		if (result !== null && !result.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("result is not owned by this resolved types")
 		return result
 	}
@@ -216,13 +216,13 @@ class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStackedResol
 	}
 	
 	override reassignType(JvmIdentifiableElement identifiable, LightweightTypeReference reference) {
-		if (reference != null && !reference.isOwnedBy(getReferenceOwner()))
+		if (reference !== null && !reference.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("reference is not owned by this resolved types")
 		super.reassignType(identifiable, reference)
 	}
 	
 	override acceptHint(Object handle, LightweightBoundTypeArgument boundTypeArgument) {
-		if (boundTypeArgument.typeReference != null && !boundTypeArgument.typeReference.isOwnedBy(getReferenceOwner()))
+		if (boundTypeArgument.typeReference !== null && !boundTypeArgument.typeReference.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("reference is not owned by this resolved types")
 		super.acceptHint(handle, boundTypeArgument)
 	}
@@ -230,7 +230,7 @@ class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStackedResol
 	override protected getHints(Object handle) {
 		val result = super.getHints(handle)
 		result.forEach[ 
-			if (typeReference != null && !typeReference.isOwnedBy(referenceOwner))
+			if (typeReference !== null && !typeReference.isOwnedBy(referenceOwner))
 				throw new IllegalArgumentException("reference is not owned by this resolved types")
 		]
 		return result
@@ -247,7 +247,7 @@ class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStackedResol
 	override getAllHints(Object handle) {
 		val result = super.getAllHints(handle)
 		result.forEach [
-			if (typeReference != null && !typeReference.isOwnedBy(getReferenceOwner()))
+			if (typeReference !== null && !typeReference.isOwnedBy(getReferenceOwner()))
 				throw new IllegalArgumentException("hint is not owned by this resolved types")
 		]
 		return result
@@ -298,7 +298,7 @@ class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStackedResol
 				throw new IllegalArgumentException("result is not owned by this resolved types")
 		]
 		val result = super.mergeTypeData(expression, allValues, returnType, nullIfEmpty)
-		if (result != null && !result.isOwnedBy(getReferenceOwner()))
+		if (result !== null && !result.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("result is not owned by this resolved types")
 		return result
 	}
@@ -330,13 +330,13 @@ class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
 	}
 	
 	override reassignType(JvmIdentifiableElement identifiable, LightweightTypeReference reference) {
-		if (reference != null && !reference.isOwnedBy(getReferenceOwner()))
+		if (reference !== null && !reference.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("reference is not owned by this resolved types")
 		super.reassignType(identifiable, reference)
 	}
 	
 	override acceptHint(Object handle, LightweightBoundTypeArgument boundTypeArgument) {
-		if (boundTypeArgument.typeReference != null && !boundTypeArgument.typeReference.isOwnedBy(getReferenceOwner()))
+		if (boundTypeArgument.typeReference !== null && !boundTypeArgument.typeReference.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("reference is not owned by this resolved types")
 		super.acceptHint(handle, boundTypeArgument)
 	}
@@ -344,7 +344,7 @@ class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
 	override protected getHints(Object handle) {
 		val result = super.getHints(handle)
 		result.forEach[ 
-			if (typeReference != null && !typeReference.isOwnedBy(referenceOwner))
+			if (typeReference !== null && !typeReference.isOwnedBy(referenceOwner))
 				throw new IllegalArgumentException("reference is not owned by this resolved types")
 		]
 		return result
@@ -361,7 +361,7 @@ class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
 	override getAllHints(Object handle) {
 		val result = super.getAllHints(handle)
 		result.forEach [
-			if (typeReference != null && !typeReference.isOwnedBy(getReferenceOwner()))
+			if (typeReference !== null && !typeReference.isOwnedBy(getReferenceOwner()))
 				throw new IllegalArgumentException("hint is not owned by this resolved types")
 		]
 		return result
@@ -383,7 +383,7 @@ class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
 	
 	override getActualType(XExpression expression) {
 		val result = super.getActualType(expression)
-		if (result != null && !result.isOwnedBy(getReferenceOwner()))
+		if (result !== null && !result.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("result is not owned by this resolved types")
 		return result
 	}
@@ -443,13 +443,13 @@ class ValidatingReassigningResolvedTypes extends ReassigningStackedResolvedTypes
 	}
 	
 	override reassignType(JvmIdentifiableElement identifiable, LightweightTypeReference reference) {
-		if (reference != null && !reference.isOwnedBy(getReferenceOwner()))
+		if (reference !== null && !reference.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("reference is not owned by this resolved types")
 		super.reassignType(identifiable, reference)
 	}
 	
 	override acceptHint(Object handle, LightweightBoundTypeArgument boundTypeArgument) {
-		if (boundTypeArgument.typeReference != null && !boundTypeArgument.typeReference.isOwnedBy(getReferenceOwner()))
+		if (boundTypeArgument.typeReference !== null && !boundTypeArgument.typeReference.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("reference is not owned by this resolved types")
 		super.acceptHint(handle, boundTypeArgument)
 	}
@@ -457,7 +457,7 @@ class ValidatingReassigningResolvedTypes extends ReassigningStackedResolvedTypes
 	override protected getHints(Object handle) {
 		val result = super.getHints(handle)
 		result.forEach[ 
-			if (typeReference != null && !typeReference.isOwnedBy(referenceOwner))
+			if (typeReference !== null && !typeReference.isOwnedBy(referenceOwner))
 				throw new IllegalArgumentException("reference is not owned by this resolved types")
 		]
 		return result
@@ -474,7 +474,7 @@ class ValidatingReassigningResolvedTypes extends ReassigningStackedResolvedTypes
 	override getAllHints(Object handle) {
 		val result = super.getAllHints(handle)
 		result.forEach [
-			if (typeReference != null &&!typeReference.isOwnedBy(getReferenceOwner()))
+			if (typeReference !== null &&!typeReference.isOwnedBy(getReferenceOwner()))
 				throw new IllegalArgumentException("hint is not owned by this resolved types")
 		]
 		return result
@@ -496,7 +496,7 @@ class ValidatingReassigningResolvedTypes extends ReassigningStackedResolvedTypes
 	
 	override getActualType(XExpression expression) {
 		val result = super.getActualType(expression)
-		if (result != null && !result.isOwnedBy(getReferenceOwner()))
+		if (result !== null && !result.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("result is not owned by this resolved types")
 		return result
 	}

--- a/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingExpressionAwareResolvedTypes.java
+++ b/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingExpressionAwareResolvedTypes.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.tests.typesystem;
 
-import com.google.common.base.Objects;
 import java.util.List;
 import java.util.function.Consumer;
 import org.eclipse.xtext.common.types.JvmIdentifiableElement;
@@ -58,7 +57,7 @@ public class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStack
   
   @Override
   public void reassignType(final JvmIdentifiableElement identifiable, final LightweightTypeReference reference) {
-    if (((!Objects.equal(reference, null)) && (!reference.isOwnedBy(this.getReferenceOwner())))) {
+    if (((reference != null) && (!reference.isOwnedBy(this.getReferenceOwner())))) {
       throw new IllegalArgumentException("reference is not owned by this resolved types");
     }
     super.reassignType(identifiable, reference);
@@ -66,7 +65,7 @@ public class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStack
   
   @Override
   public void acceptHint(final Object handle, final LightweightBoundTypeArgument boundTypeArgument) {
-    if (((!Objects.equal(boundTypeArgument.getTypeReference(), null)) && (!boundTypeArgument.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
+    if (((boundTypeArgument.getTypeReference() != null) && (!boundTypeArgument.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
       throw new IllegalArgumentException("reference is not owned by this resolved types");
     }
     super.acceptHint(handle, boundTypeArgument);
@@ -76,7 +75,7 @@ public class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStack
   protected List<LightweightBoundTypeArgument> getHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getHints(handle);
     final Consumer<LightweightBoundTypeArgument> _function = (LightweightBoundTypeArgument it) -> {
-      if (((!Objects.equal(it.getTypeReference(), null)) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
+      if (((it.getTypeReference() != null) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
         throw new IllegalArgumentException("reference is not owned by this resolved types");
       }
     };
@@ -109,7 +108,7 @@ public class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStack
   public List<LightweightBoundTypeArgument> getAllHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getAllHints(handle);
     final Consumer<LightweightBoundTypeArgument> _function = (LightweightBoundTypeArgument it) -> {
-      if (((!Objects.equal(it.getTypeReference(), null)) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
+      if (((it.getTypeReference() != null) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
         throw new IllegalArgumentException("hint is not owned by this resolved types");
       }
     };
@@ -198,7 +197,7 @@ public class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStack
     };
     allValues.forEach(_function);
     final TypeData result = super.mergeTypeData(expression, allValues, returnType, nullIfEmpty);
-    if (((!Objects.equal(result, null)) && (!result.isOwnedBy(this.getReferenceOwner())))) {
+    if (((result != null) && (!result.isOwnedBy(this.getReferenceOwner())))) {
       throw new IllegalArgumentException("result is not owned by this resolved types");
     }
     return result;

--- a/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingReassigningResolvedTypes.java
+++ b/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingReassigningResolvedTypes.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.tests.typesystem;
 
-import com.google.common.base.Objects;
 import java.util.List;
 import java.util.function.Consumer;
 import org.eclipse.xtext.common.types.JvmIdentifiableElement;
@@ -59,7 +58,7 @@ public class ValidatingReassigningResolvedTypes extends ReassigningStackedResolv
   
   @Override
   public void reassignType(final JvmIdentifiableElement identifiable, final LightweightTypeReference reference) {
-    if (((!Objects.equal(reference, null)) && (!reference.isOwnedBy(this.getReferenceOwner())))) {
+    if (((reference != null) && (!reference.isOwnedBy(this.getReferenceOwner())))) {
       throw new IllegalArgumentException("reference is not owned by this resolved types");
     }
     super.reassignType(identifiable, reference);
@@ -67,7 +66,7 @@ public class ValidatingReassigningResolvedTypes extends ReassigningStackedResolv
   
   @Override
   public void acceptHint(final Object handle, final LightweightBoundTypeArgument boundTypeArgument) {
-    if (((!Objects.equal(boundTypeArgument.getTypeReference(), null)) && (!boundTypeArgument.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
+    if (((boundTypeArgument.getTypeReference() != null) && (!boundTypeArgument.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
       throw new IllegalArgumentException("reference is not owned by this resolved types");
     }
     super.acceptHint(handle, boundTypeArgument);
@@ -77,7 +76,7 @@ public class ValidatingReassigningResolvedTypes extends ReassigningStackedResolv
   protected List<LightweightBoundTypeArgument> getHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getHints(handle);
     final Consumer<LightweightBoundTypeArgument> _function = (LightweightBoundTypeArgument it) -> {
-      if (((!Objects.equal(it.getTypeReference(), null)) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
+      if (((it.getTypeReference() != null) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
         throw new IllegalArgumentException("reference is not owned by this resolved types");
       }
     };
@@ -110,7 +109,7 @@ public class ValidatingReassigningResolvedTypes extends ReassigningStackedResolv
   public List<LightweightBoundTypeArgument> getAllHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getAllHints(handle);
     final Consumer<LightweightBoundTypeArgument> _function = (LightweightBoundTypeArgument it) -> {
-      if (((!Objects.equal(it.getTypeReference(), null)) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
+      if (((it.getTypeReference() != null) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
         throw new IllegalArgumentException("hint is not owned by this resolved types");
       }
     };
@@ -145,7 +144,7 @@ public class ValidatingReassigningResolvedTypes extends ReassigningStackedResolv
   @Override
   public LightweightTypeReference getActualType(final XExpression expression) {
     final LightweightTypeReference result = super.getActualType(expression);
-    if (((!Objects.equal(result, null)) && (!result.isOwnedBy(this.getReferenceOwner())))) {
+    if (((result != null) && (!result.isOwnedBy(this.getReferenceOwner())))) {
       throw new IllegalArgumentException("result is not owned by this resolved types");
     }
     return result;

--- a/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingRootResolvedTypes.java
+++ b/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingRootResolvedTypes.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.tests.typesystem;
 
-import com.google.common.base.Objects;
 import java.util.List;
 import java.util.function.Consumer;
 import org.eclipse.xtext.common.types.JvmIdentifiableElement;
@@ -64,7 +63,7 @@ public class ValidatingRootResolvedTypes extends RootResolvedTypes {
   
   @Override
   public void reassignType(final JvmIdentifiableElement identifiable, final LightweightTypeReference reference) {
-    if (((!Objects.equal(reference, null)) && (!reference.isOwnedBy(this.getReferenceOwner())))) {
+    if (((reference != null) && (!reference.isOwnedBy(this.getReferenceOwner())))) {
       throw new IllegalArgumentException("reference is not owned by this resolved types");
     }
     super.reassignType(identifiable, reference);
@@ -72,7 +71,7 @@ public class ValidatingRootResolvedTypes extends RootResolvedTypes {
   
   @Override
   public void acceptHint(final Object handle, final LightweightBoundTypeArgument boundTypeArgument) {
-    if (((!Objects.equal(boundTypeArgument.getTypeReference(), null)) && (!boundTypeArgument.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
+    if (((boundTypeArgument.getTypeReference() != null) && (!boundTypeArgument.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
       throw new IllegalArgumentException("reference is not owned by this resolved types");
     }
     super.acceptHint(handle, boundTypeArgument);
@@ -82,7 +81,7 @@ public class ValidatingRootResolvedTypes extends RootResolvedTypes {
   protected List<LightweightBoundTypeArgument> getHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getHints(handle);
     final Consumer<LightweightBoundTypeArgument> _function = (LightweightBoundTypeArgument it) -> {
-      if (((!Objects.equal(it.getTypeReference(), null)) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
+      if (((it.getTypeReference() != null) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
         throw new IllegalArgumentException("reference is not owned by this resolved types");
       }
     };
@@ -115,7 +114,7 @@ public class ValidatingRootResolvedTypes extends RootResolvedTypes {
   public List<LightweightBoundTypeArgument> getAllHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getAllHints(handle);
     final Consumer<LightweightBoundTypeArgument> _function = (LightweightBoundTypeArgument it) -> {
-      if (((!Objects.equal(it.getTypeReference(), null)) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
+      if (((it.getTypeReference() != null) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
         throw new IllegalArgumentException("hint is not owned by this resolved types");
       }
     };
@@ -150,7 +149,7 @@ public class ValidatingRootResolvedTypes extends RootResolvedTypes {
   @Override
   public LightweightTypeReference getActualType(final XExpression expression) {
     final LightweightTypeReference result = super.getActualType(expression);
-    if (((!Objects.equal(result, null)) && (!result.isOwnedBy(this.getReferenceOwner())))) {
+    if (((result != null) && (!result.isOwnedBy(this.getReferenceOwner())))) {
       throw new IllegalArgumentException("result is not owned by this resolved types");
     }
     return result;
@@ -159,7 +158,7 @@ public class ValidatingRootResolvedTypes extends RootResolvedTypes {
   @Override
   public LightweightTypeReference getExpectedType(final XExpression expression) {
     final LightweightTypeReference result = super.getExpectedType(expression);
-    if (((!Objects.equal(result, null)) && (!result.isOwnedBy(this.getReferenceOwner())))) {
+    if (((result != null) && (!result.isOwnedBy(this.getReferenceOwner())))) {
       throw new IllegalArgumentException("result is not owned by this resolved types");
     }
     return result;

--- a/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingStackedResolvedTypes.java
+++ b/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingStackedResolvedTypes.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.tests.typesystem;
 
-import com.google.common.base.Objects;
 import java.util.List;
 import java.util.function.Consumer;
 import org.eclipse.xtext.common.types.JvmIdentifiableElement;
@@ -58,7 +57,7 @@ public class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
   
   @Override
   public void reassignType(final JvmIdentifiableElement identifiable, final LightweightTypeReference reference) {
-    if (((!Objects.equal(reference, null)) && (!reference.isOwnedBy(this.getReferenceOwner())))) {
+    if (((reference != null) && (!reference.isOwnedBy(this.getReferenceOwner())))) {
       throw new IllegalArgumentException("reference is not owned by this resolved types");
     }
     super.reassignType(identifiable, reference);
@@ -66,7 +65,7 @@ public class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
   
   @Override
   public void acceptHint(final Object handle, final LightweightBoundTypeArgument boundTypeArgument) {
-    if (((!Objects.equal(boundTypeArgument.getTypeReference(), null)) && (!boundTypeArgument.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
+    if (((boundTypeArgument.getTypeReference() != null) && (!boundTypeArgument.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
       throw new IllegalArgumentException("reference is not owned by this resolved types");
     }
     super.acceptHint(handle, boundTypeArgument);
@@ -76,7 +75,7 @@ public class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
   protected List<LightweightBoundTypeArgument> getHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getHints(handle);
     final Consumer<LightweightBoundTypeArgument> _function = (LightweightBoundTypeArgument it) -> {
-      if (((!Objects.equal(it.getTypeReference(), null)) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
+      if (((it.getTypeReference() != null) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
         throw new IllegalArgumentException("reference is not owned by this resolved types");
       }
     };
@@ -109,7 +108,7 @@ public class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
   public List<LightweightBoundTypeArgument> getAllHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getAllHints(handle);
     final Consumer<LightweightBoundTypeArgument> _function = (LightweightBoundTypeArgument it) -> {
-      if (((!Objects.equal(it.getTypeReference(), null)) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
+      if (((it.getTypeReference() != null) && (!it.getTypeReference().isOwnedBy(this.getReferenceOwner())))) {
         throw new IllegalArgumentException("hint is not owned by this resolved types");
       }
     };
@@ -144,7 +143,7 @@ public class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
   @Override
   public LightweightTypeReference getActualType(final XExpression expression) {
     final LightweightTypeReference result = super.getActualType(expression);
-    if (((!Objects.equal(result, null)) && (!result.isOwnedBy(this.getReferenceOwner())))) {
+    if (((result != null) && (!result.isOwnedBy(this.getReferenceOwner())))) {
       throw new IllegalArgumentException("result is not owned by this resolved types");
     }
     return result;

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/junit/typesystem/Oven.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/junit/typesystem/Oven.xtend
@@ -51,15 +51,15 @@ class Oven extends Assert {
 			val file = input.parse
 			val resolvedTypes = typeResolver.resolveTypes(file)
 			assertNotNull(resolvedTypes)
-			if (file != null) {
+			if (file !== null) {
 				for(content: file.eAllContents.toIterable) {
 					switch(content) {
 						XAbstractFeatureCall: {
 							assertExpressionTypeIsResolved(content, resolvedTypes)
-							if (content.implicitReceiver != null) {
+							if (content.implicitReceiver !== null) {
 								assertExpressionTypeIsResolved(content.implicitReceiver, resolvedTypes)
 							}
-							if (content.implicitFirstArgument != null) {
+							if (content.implicitFirstArgument !== null) {
 								assertExpressionTypeIsResolved(content.implicitFirstArgument, resolvedTypes)
 							}
 						}
@@ -98,11 +98,11 @@ class Oven extends Assert {
 			} 
 			default: internalTypes.invoke("getTypeData", expression, Boolean.FALSE) as TypeData
 		}
-		assertTrue("Type is not resolved. Expression: " + expression.toString, if (expression instanceof XAbstractFeatureCall) expression.packageFragment || type != null else type != null)
+		assertTrue("Type is not resolved. Expression: " + expression.toString, if (expression instanceof XAbstractFeatureCall) expression.packageFragment || type !== null else type !== null)
 	}
 	
 	def void assertIdentifiableTypeIsResolved(JvmIdentifiableElement identifiable, IResolvedTypes types) {
-		if (identifiable.simpleName == null)
+		if (identifiable.simpleName === null)
 			return;
 		val type = types.getActualType(identifiable)
 		assertNotNull(identifiable.toString, type)

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/interpreter/SwitchConstantExpressionsInterpreterTest.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/interpreter/SwitchConstantExpressionsInterpreterTest.xtend
@@ -78,7 +78,7 @@ class SwitchConstantExpressionsInterpreterTest extends AbstractXbaseTestCase {
 		val expression = typeAndExpression.value
 		val charSequence = '''
 		{
-			val«IF type != null» «type»«ENDIF» testFoo = «expression»
+			val«IF type !== null» «type»«ENDIF» testFoo = «expression»
 		}
 		'''
 		val blockExpression = expression(charSequence, true) as XBlockExpression

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/linking/BatchLinkingTest.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/linking/BatchLinkingTest.xtend
@@ -42,7 +42,7 @@ class BatchLinkingTest extends AbstractXbaseLinkingTest {
 			switch(content) {
 				XAbstractFeatureCall: {
 					assertExpressionTypeIsResolved(content, resolvedTypes)
-					if (content.implicitReceiver != null) {
+					if (content.implicitReceiver !== null) {
 						assertExpressionTypeIsResolved(content.implicitReceiver, resolvedTypes)
 					}
 				}

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/resources/ResourceStorageTest.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/resources/ResourceStorageTest.xtend
@@ -147,7 +147,7 @@ class ResourceStorageTest extends AbstractXbaseTestCase {
 			assertSame(orig.grammarElement, rest.grammarElement)
 			
 			assertTrue(orig.semanticElement !== null && rest.semanticElement !== null || orig.semanticElement === null && rest.semanticElement === null)
-			if (orig.semanticElement != null) {
+			if (orig.semanticElement !== null) {
 				assertEquals(file.eResource.getURIFragment(orig.semanticElement),resource.getURIFragment(rest.semanticElement))
 			}
 			

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractClosureTypeTest.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractClosureTypeTest.xtend
@@ -1245,7 +1245,7 @@ abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 	}
 	
 	@Test def void testFeatureCall_014() throws Exception {
-		"newArrayList('').map(s|s != null)"
+		"newArrayList('').map(s|s !== null)"
 			.resolvesClosuresTo("(String)=>boolean")
 			.withEquivalents("Function1<String, Boolean>")
 	}
@@ -1696,7 +1696,7 @@ abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 	}
 	
 	@Test def void testFeatureCall_084() throws Exception {
-		"newArrayList('').map(s| return s != null)"
+		"newArrayList('').map(s| return s !== null)"
 			.resolvesClosuresTo("(String)=>boolean")
 			.withEquivalents("Function1<String, Boolean>")
 	}

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractFeatureCallTypeTest.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractFeatureCallTypeTest.xtend
@@ -687,7 +687,7 @@ abstract class AbstractFeatureCallTypeTest extends AbstractXbaseTestCase {
 	}
 	
 	@Test def void testFeatureCall_08() throws Exception {
-		"newArrayList('').map(s|s != null)".resolvesFeatureCallsTo("ArrayList<String>", "List<Boolean>", "String", "boolean")
+		"newArrayList('').map(s|s !== null)".resolvesFeatureCallsTo("ArrayList<String>", "List<Boolean>", "String", "boolean")
 	}
 	
 	@Test def void testFeatureCall_11() throws Exception {

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractIdentifiableTypeTest.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractIdentifiableTypeTest.xtend
@@ -48,7 +48,7 @@ abstract class AbstractIdentifiableTypeTest extends AbstractXbaseTestCase {
 				default: #[it] 
 			}
 		].toIterable.flatten.toSet.filter [
-			it != null && switch(it) {
+			it !== null && switch(it) {
 				XVariableDeclaration: true
 				JvmFormalParameter: true
 				default: false
@@ -56,7 +56,7 @@ abstract class AbstractIdentifiableTypeTest extends AbstractXbaseTestCase {
 		].filter(JvmIdentifiableElement).toList
 		return identifiables.sortBy [ 
 			val node = NodeModelUtils::findActualNodeFor(it)
-			if (node != null) 
+			if (node !== null) 
 				node.offset
 			else
 				NodeModelUtils::findActualNodeFor(it.eContainer).offset

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractTypeArgumentTest.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractTypeArgumentTest.xtend
@@ -913,7 +913,7 @@ abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 	}
 	
 	@Test def void testFeatureCall_26() throws Exception {
-		"newArrayList('').map(s|s != null)".bindTypeArgumentsTo("String").and("String", "Boolean").done
+		"newArrayList('').map(s|s !== null)".bindTypeArgumentsTo("String").and("String", "Boolean").done
 	}
 	
 	@Test def void testFeatureCall_27() throws Exception {

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractTypeResolverTest.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractTypeResolverTest.xtend
@@ -1991,7 +1991,7 @@ abstract class AbstractTypeResolverTest<Reference> extends AbstractXbaseTestCase
 	}
 	
 	@Test def void testFeatureCall_08() throws Exception {
-		"newArrayList('').map(s|s != null)".resolvesTo("List<Boolean>")
+		"newArrayList('').map(s|s !== null)".resolvesTo("List<Boolean>")
 	}
 	
 	@Test def void testFeatureCall_09() throws Exception {

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/BatchTypeResolverTests.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/BatchTypeResolverTests.xtend
@@ -45,7 +45,7 @@ abstract class AbstractBatchTypeResolverTest extends AbstractTypeResolverTest<Li
 			switch(content) {
 				XAbstractFeatureCall: {
 					assertExpressionTypeIsResolved(content, resolvedTypes)
-					if (content.implicitReceiver != null) {
+					if (content.implicitReceiver !== null) {
 						assertExpressionTypeIsResolved(content.implicitReceiver, resolvedTypes)
 					}
 				}
@@ -68,7 +68,7 @@ abstract class AbstractBatchTypeResolverTest extends AbstractTypeResolverTest<Li
 					val feature = content.eGet(XbasePackage.Literals::XABSTRACT_FEATURE_CALL__FEATURE, false) as InternalEObject
 					assertNotNull(content.toString, feature)
 					assertFalse(content.toString, feature.eIsProxy())
-					if (content.implicitReceiver != null) {
+					if (content.implicitReceiver !== null) {
 						val implicitFeature = content.implicitReceiver.eGet(XbasePackage.Literals::XABSTRACT_FEATURE_CALL__FEATURE, false) as InternalEObject
 						assertNotNull(implicitFeature.toString, feature)
 						assertFalse(implicitFeature.toString, feature.eIsProxy())

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/junit/typesystem/Oven.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/junit/typesystem/Oven.java
@@ -8,7 +8,6 @@
 package org.eclipse.xtext.xbase.junit.typesystem;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.lang.reflect.Method;
@@ -66,8 +65,7 @@ public class Oven extends Assert {
       final EObject file = this._parseHelper.parse(input);
       final IResolvedTypes resolvedTypes = this.typeResolver.resolveTypes(file);
       Assert.assertNotNull(resolvedTypes);
-      boolean _notEquals = (!Objects.equal(file, null));
-      if (_notEquals) {
+      if ((file != null)) {
         TreeIterator<EObject> _eAllContents = file.eAllContents();
         Iterable<EObject> _iterable = IteratorExtensions.<EObject>toIterable(_eAllContents);
         for (final EObject content : _iterable) {
@@ -76,14 +74,14 @@ public class Oven extends Assert {
             _matched=true;
             this.assertExpressionTypeIsResolved(((XExpression)content), resolvedTypes);
             XExpression _implicitReceiver = ((XAbstractFeatureCall)content).getImplicitReceiver();
-            boolean _notEquals_1 = (!Objects.equal(_implicitReceiver, null));
-            if (_notEquals_1) {
+            boolean _tripleNotEquals = (_implicitReceiver != null);
+            if (_tripleNotEquals) {
               XExpression _implicitReceiver_1 = ((XAbstractFeatureCall)content).getImplicitReceiver();
               this.assertExpressionTypeIsResolved(_implicitReceiver_1, resolvedTypes);
             }
             XExpression _implicitFirstArgument = ((XAbstractFeatureCall)content).getImplicitFirstArgument();
-            boolean _notEquals_2 = (!Objects.equal(_implicitFirstArgument, null));
-            if (_notEquals_2) {
+            boolean _tripleNotEquals_1 = (_implicitFirstArgument != null);
+            if (_tripleNotEquals_1) {
               XExpression _implicitFirstArgument_1 = ((XAbstractFeatureCall)content).getImplicitFirstArgument();
               this.assertExpressionTypeIsResolved(_implicitFirstArgument_1, resolvedTypes);
             }
@@ -157,9 +155,9 @@ public class Oven extends Assert {
       String _plus = ("Type is not resolved. Expression: " + _string);
       boolean _xifexpression = false;
       if ((expression instanceof XAbstractFeatureCall)) {
-        _xifexpression = (((XAbstractFeatureCall)expression).isPackageFragment() || (!Objects.equal(type, null)));
+        _xifexpression = (((XAbstractFeatureCall)expression).isPackageFragment() || (type != null));
       } else {
-        _xifexpression = (!Objects.equal(type, null));
+        _xifexpression = (type != null);
       }
       Assert.assertTrue(_plus, _xifexpression);
     } catch (Throwable _e) {
@@ -169,8 +167,8 @@ public class Oven extends Assert {
   
   public void assertIdentifiableTypeIsResolved(final JvmIdentifiableElement identifiable, final IResolvedTypes types) {
     String _simpleName = identifiable.getSimpleName();
-    boolean _equals = Objects.equal(_simpleName, null);
-    if (_equals) {
+    boolean _tripleEquals = (_simpleName == null);
+    if (_tripleEquals) {
       return;
     }
     final LightweightTypeReference type = types.getActualType(identifiable);

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/interpreter/SwitchConstantExpressionsInterpreterTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/interpreter/SwitchConstantExpressionsInterpreterTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.tests.interpreter;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.xtend2.lib.StringConcatenation;
@@ -131,8 +130,7 @@ public class SwitchConstantExpressionsInterpreterTest extends AbstractXbaseTestC
       _builder.append("\t");
       _builder.append("val");
       {
-        boolean _notEquals = (!Objects.equal(type, null));
-        if (_notEquals) {
+        if ((type != null)) {
           _builder.append(" ");
           _builder.append(type, "\t");
         }

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/linking/BatchLinkingTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/linking/BatchLinkingTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.tests.linking;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
@@ -54,8 +53,8 @@ public class BatchLinkingTest extends AbstractXbaseLinkingTest {
         _matched=true;
         this.assertExpressionTypeIsResolved(((XExpression)content), resolvedTypes);
         XExpression _implicitReceiver = ((XAbstractFeatureCall)content).getImplicitReceiver();
-        boolean _notEquals = (!Objects.equal(_implicitReceiver, null));
-        if (_notEquals) {
+        boolean _tripleNotEquals = (_implicitReceiver != null);
+        if (_tripleNotEquals) {
           XExpression _implicitReceiver_1 = ((XAbstractFeatureCall)content).getImplicitReceiver();
           this.assertExpressionTypeIsResolved(_implicitReceiver_1, resolvedTypes);
         }

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/resources/ResourceStorageTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/resources/ResourceStorageTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.tests.resources;
 
-import com.google.common.base.Objects;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -227,8 +226,8 @@ public class ResourceStorageTest extends AbstractXbaseTestCase {
           Assert.assertSame(_grammarElement, _grammarElement_1);
           Assert.assertTrue((((orig.getSemanticElement() != null) && (rest.getSemanticElement() != null)) || ((orig.getSemanticElement() == null) && (rest.getSemanticElement() == null))));
           EObject _semanticElement = orig.getSemanticElement();
-          boolean _notEquals = (!Objects.equal(_semanticElement, null));
-          if (_notEquals) {
+          boolean _tripleNotEquals = (_semanticElement != null);
+          if (_tripleNotEquals) {
             Resource _eResource_3 = file.eResource();
             EObject _semanticElement_1 = orig.getSemanticElement();
             String _uRIFragment = _eResource_3.getURIFragment(_semanticElement_1);

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/AbstractBatchTypeResolverTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/AbstractBatchTypeResolverTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.tests.typesystem;
 
-import com.google.common.base.Objects;
 import java.util.List;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.TreeIterator;
@@ -73,8 +72,8 @@ public abstract class AbstractBatchTypeResolverTest extends AbstractTypeResolver
           _matched=true;
           this.assertExpressionTypeIsResolved(((XExpression)content), resolvedTypes);
           XExpression _implicitReceiver = ((XAbstractFeatureCall)content).getImplicitReceiver();
-          boolean _notEquals = (!Objects.equal(_implicitReceiver, null));
-          if (_notEquals) {
+          boolean _tripleNotEquals = (_implicitReceiver != null);
+          if (_tripleNotEquals) {
             XExpression _implicitReceiver_1 = ((XAbstractFeatureCall)content).getImplicitReceiver();
             this.assertExpressionTypeIsResolved(_implicitReceiver_1, resolvedTypes);
           }
@@ -117,8 +116,8 @@ public abstract class AbstractBatchTypeResolverTest extends AbstractTypeResolver
             boolean _eIsProxy = feature.eIsProxy();
             Assert.assertFalse(_string_3, _eIsProxy);
             XExpression _implicitReceiver = ((XAbstractFeatureCall)content_1).getImplicitReceiver();
-            boolean _notEquals = (!Objects.equal(_implicitReceiver, null));
-            if (_notEquals) {
+            boolean _tripleNotEquals = (_implicitReceiver != null);
+            if (_tripleNotEquals) {
               XExpression _implicitReceiver_1 = ((XAbstractFeatureCall)content_1).getImplicitReceiver();
               Object _eGet_1 = _implicitReceiver_1.eGet(XbasePackage.Literals.XABSTRACT_FEATURE_CALL__FEATURE, false);
               final InternalEObject implicitFeature = ((InternalEObject) _eGet_1);

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/AbstractClosureTypeTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/AbstractClosureTypeTest.java
@@ -1260,7 +1260,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
   
   @Test
   public void testFeatureCall_014() throws Exception {
-    List<Object> _resolvesClosuresTo = this.resolvesClosuresTo("newArrayList(\'\').map(s|s != null)", "(String)=>boolean");
+    List<Object> _resolvesClosuresTo = this.resolvesClosuresTo("newArrayList(\'\').map(s|s !== null)", "(String)=>boolean");
     this.withEquivalents(_resolvesClosuresTo, "Function1<String, Boolean>");
   }
   
@@ -1686,7 +1686,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
   
   @Test
   public void testFeatureCall_084() throws Exception {
-    List<Object> _resolvesClosuresTo = this.resolvesClosuresTo("newArrayList(\'\').map(s| return s != null)", "(String)=>boolean");
+    List<Object> _resolvesClosuresTo = this.resolvesClosuresTo("newArrayList(\'\').map(s| return s !== null)", "(String)=>boolean");
     this.withEquivalents(_resolvesClosuresTo, "Function1<String, Boolean>");
   }
   

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/AbstractFeatureCallTypeTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/AbstractFeatureCallTypeTest.java
@@ -680,7 +680,7 @@ public abstract class AbstractFeatureCallTypeTest extends AbstractXbaseTestCase 
   
   @Test
   public void testFeatureCall_08() throws Exception {
-    this.resolvesFeatureCallsTo("newArrayList(\'\').map(s|s != null)", "ArrayList<String>", "List<Boolean>", "String", "boolean");
+    this.resolvesFeatureCallsTo("newArrayList(\'\').map(s|s !== null)", "ArrayList<String>", "List<Boolean>", "String", "boolean");
   }
   
   @Test

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/AbstractIdentifiableTypeTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/AbstractIdentifiableTypeTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.tests.typesystem;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import java.util.Collections;
 import java.util.HashSet;
@@ -75,8 +74,7 @@ public abstract class AbstractIdentifiableTypeTest extends AbstractXbaseTestCase
     Set<EObject> _set = IterableExtensions.<EObject>toSet(_flatten);
     final Function1<EObject, Boolean> _function_1 = (EObject it) -> {
       boolean _and = false;
-      boolean _notEquals = (!Objects.equal(it, null));
-      if (!_notEquals) {
+      if (!(it != null)) {
         _and = false;
       } else {
         boolean _switchResult = false;
@@ -106,8 +104,7 @@ public abstract class AbstractIdentifiableTypeTest extends AbstractXbaseTestCase
       {
         final ICompositeNode node = NodeModelUtils.findActualNodeFor(it);
         int _xifexpression = (int) 0;
-        boolean _notEquals = (!Objects.equal(node, null));
-        if (_notEquals) {
+        if ((node != null)) {
           _xifexpression = node.getOffset();
         } else {
           EObject _eContainer = it.eContainer();

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/AbstractTypeArgumentTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/AbstractTypeArgumentTest.java
@@ -1263,7 +1263,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
   
   @Test
   public void testFeatureCall_26() throws Exception {
-    Iterator<XExpression> _bindTypeArgumentsTo = this.bindTypeArgumentsTo("newArrayList(\'\').map(s|s != null)", "String");
+    Iterator<XExpression> _bindTypeArgumentsTo = this.bindTypeArgumentsTo("newArrayList(\'\').map(s|s !== null)", "String");
     Iterator<XExpression> _and = this.and(_bindTypeArgumentsTo, "String", "Boolean");
     this.done(_and);
   }

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/AbstractTypeResolverTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/AbstractTypeResolverTest.java
@@ -2130,7 +2130,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
   
   @Test
   public void testFeatureCall_08() throws Exception {
-    this.resolvesTo("newArrayList(\'\').map(s|s != null)", "List<Boolean>");
+    this.resolvesTo("newArrayList(\'\').map(s|s !== null)", "List<Boolean>");
   }
   
   @Test

--- a/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/FormattableDocument.xtend
+++ b/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/FormattableDocument.xtend
@@ -35,11 +35,11 @@ class FormattableDocument {
 	}
 	
 	def boolean isDebugConflicts() {
-		rootTrace != null
+		rootTrace !== null
 	}
 	
 	def protected addFormatting(FormattingData data) {
-		if(data != null) {
+		if(data !== null) {
 			if(data.length < 0) {
 				val text = getTextAround(data)
 				log.error('''
@@ -64,8 +64,8 @@ class FormattableDocument {
 				}
 			}
 			val old = formattings.get(data.offset)
-			val newData = if(old == null) data else merge(old, data)
-			if(newData != null)
+			val newData = if(old === null) data else merge(old, data)
+			if(newData !== null)
 				formattings.put(data.offset, newData)
 		}
 	}
@@ -82,7 +82,7 @@ class FormattableDocument {
 			indentationChange = data2.indentationChange + data1.indentationChange
 			old = data2
 		}
-		if(old != null) {
+		if(old !== null) {
 			if(indentationChange > 0)
 				increaseIndentationChange = indentationChange
 			else
@@ -136,12 +136,12 @@ class FormattableDocument {
 	}
 	
 	def operator_add(Iterable<FormattingData> data) {
-		if(data != null)
+		if(data !== null)
 			data.forEach[addFormatting]
 	}
 	
 	def operator_add((FormattableDocument) => Iterable<FormattingData> data) {
-		if(data != null)
+		if(data !== null)
 			operator_add(data.apply(this))
 	}
 	
@@ -159,7 +159,7 @@ class FormattableDocument {
 				val textlength = f.offset - oldOffset
 				switch f {
 					WhitespaceData: {
-						if (f.space != null) {
+						if (f.space !== null) {
 							val replacement = f.space
 							replacements += new TextReplacement(f.offset, f.length, replacement)
 						}
@@ -239,7 +239,7 @@ class FormattableDocument {
 		for(f:formattings.subMap(lastWrap.offset + 1, offset).values) {
 			if(f instanceof WhitespaceData) {
 				val space = f.space
-				val length = if (space == null) 0 else space.length
+				val length = if (space === null) 0 else space.length
 				lengthDiff = lengthDiff + length - f.length
 			}
 		}
@@ -321,7 +321,7 @@ class FormattableDocument {
 	String space
 
 	override isEmpty() {
-		space == null
+		space === null
 	}
 }
 
@@ -332,6 +332,6 @@ class FormattableDocument {
 	Integer newLines
 	
 	override isEmpty() {
-		newLines == null
+		newLines === null
 	}
 }

--- a/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/FormattingDataFactory.xtend
+++ b/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/FormattingDataFactory.xtend
@@ -28,7 +28,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 		Void key, FormattingDataInit it) {
 		[ FormattableDocument doc |
 			val int newLines2 = newLines ?: 0
-			if ((space == null && newLines == null) || (leafs.newLinesInComments == 0 && (newLines2 == 0 || space == "")))
+			if ((space === null && newLines === null) || (leafs.newLinesInComments == 0 && (newLines2 == 0 || space == "")))
 				return newWhitespaceData(leafs, space, increaseIndentationChange, decreaseIndentationChange, doc.debugConflicts)
 			else
 				return newNewLineData(leafs, newLines2, newLines2, increaseIndentationChange, decreaseIndentationChange, doc.debugConflicts)
@@ -165,7 +165,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 		INode node,
 		(FormattingDataInit)=>void init
 	) {
-		if (node != null) {
+		if (node !== null) {
 			node.hiddenLeafsAfter.newFormattingData(init)
 		}
 	}
@@ -174,7 +174,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 		INode node,
 		(FormattingDataInit)=>void init
 	) {
-		if (node != null) {
+		if (node !== null) {
 			node.hiddenLeafsBefore.newFormattingData(init)
 		}
 	}
@@ -185,7 +185,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 	) {
 		[ FormattableDocument doc |
 			val result = <FormattingData>newArrayList()
-			if (node != null) {
+			if (node !== null) {
 				result += node.hiddenLeafsBefore.newFormattingData(init)?.apply(doc) ?: emptyList
 				result += node.hiddenLeafsAfter.newFormattingData(init)?.apply(doc) ?: emptyList
 			}
@@ -200,7 +200,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 	) {
 		[ FormattableDocument doc |
 			val result = <FormattingData>newArrayList()
-			if (node != null) {
+			if (node !== null) {
 				result += node.hiddenLeafsBefore.newFormattingData(before)?.apply(doc) ?: emptyList
 				result += node.hiddenLeafsAfter.newFormattingData(after)?.apply(doc) ?: emptyList
 			}

--- a/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/HiddenLeafAccess.xtend
+++ b/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/HiddenLeafAccess.xtend
@@ -20,7 +20,7 @@ import org.eclipse.xtext.formatting2.regionaccess.ITextRegionAccess
 	def HiddenLeafs getHiddenLeafsBefore(INode node) {
 		val start = node.findNextLeaf[!hidden]
 		val nodes = start.findPreviousHiddenLeafs
-		if(start != null)
+		if(start !== null)
 			newHiddenLeafs(if(nodes.empty) start.offset else nodes.head.offset, nodes)
 		else 
 			new HiddenLeafs(node?.offset)
@@ -56,7 +56,7 @@ import org.eclipse.xtext.formatting2.regionaccess.ITextRegionAccess
 	
 	def HiddenLeafs getHiddenLeafsAfter(INode node) {
 		val start = node.findPreviousLeaf[!hidden]
-		if(start != null)
+		if(start !== null)
 			newHiddenLeafs(start.endOffset, start.findNextHiddenLeafs)
 		else 
 			new HiddenLeafs(node?.offset)
@@ -83,7 +83,7 @@ import org.eclipse.xtext.formatting2.regionaccess.ITextRegionAccess
 			current = current.lastChild
 		if(current instanceof ILeafNode && matches.apply(current as ILeafNode))
 			return current as ILeafNode
-		if(current != null) {
+		if(current !== null) {
 			val ni = new NodeIterator(current)
 			while(ni.hasPrevious) {
 				val previous = ni.previous
@@ -99,7 +99,7 @@ import org.eclipse.xtext.formatting2.regionaccess.ITextRegionAccess
 		while(current instanceof ICompositeNode)
 			current = current.lastChild
 		val result = <ILeafNode>newArrayList
-		if(current != null) {
+		if(current !== null) {
 			val ni = new NodeIterator(current)
 			while(ni.hasPrevious) {
 				val previous = ni.previous

--- a/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/NodeModelAccess.xtend
+++ b/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/NodeModelAccess.xtend
@@ -49,11 +49,11 @@ import org.eclipse.xtext.formatting2.regionaccess.ITextRegionAccess
 			current = current.lastChild
 		val current1 = current
 		val result = current1.findNextLeaf[current1 != it && grammarElement instanceof Keyword]
-		if (result != null && result.text == kw) result
+		if (result !== null && result.text == kw) result
 	}
 
 	def ILeafNode findNextLeaf(INode node, (ILeafNode)=>boolean matches) {
-		if (node != null) {
+		if (node !== null) {
 			if (node instanceof ILeafNode && matches.apply(node as ILeafNode))
 				return node as ILeafNode
 			val ni = new NodeIterator(node)

--- a/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/XbaseFormatter2.xtend
+++ b/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/XbaseFormatter2.xtend
@@ -75,7 +75,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 				for (elem : elements) {
 					if (elem == elements.head)
 						format += open.append[newLine; increaseIndentation]
-					else if (comma != null)
+					else if (comma !== null)
 						format += comma.append[newLine]
 					if (elem == elements.last)
 						format += elem.nodeForEObject.append[newLine; decreaseIndentation]
@@ -88,12 +88,12 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 			var indented = false
 			for (elem : elements) {
 				if (format.fitsIntoLine(elem)) {
-					if (comma == null)
+					if (comma === null)
 						format += open.append[noSpace]
 					else
 						format += comma.append[oneSpace]
 				} else {
-					val n = if (comma == null) open else comma
+					val n = if (comma === null) open else comma
 					format += n.append[newLine]
 					if (!indented)
 						format += n.append[increaseIndentation]
@@ -117,7 +117,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 	def protected dispatch void format(XAnnotation ann, FormattableDocument document) {
 		ann.nodeForKeyword("@") => [document += append[noSpace]]
 		ann.nodeForKeyword("(") => [document += prepend[noSpace] document += append[noSpace]]
-		if (ann.value != null) {
+		if (ann.value !== null) {
 			ann.value.format(document)
 			ann.nodeForKeyword(")") => [document += prepend[noSpace]]
 		} else if (!ann.elementValuePairs.empty) {
@@ -209,7 +209,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 	def protected boolean fitsIntoLine(FormattableDocument fmt, EObject expression) {
 		val node = expression.nodeForEObject
 		val lookahead = fmt.lookahead(expression)
-		if (node == null || lookahead.contains("\n")) {
+		if (node === null || lookahead.contains("\n")) {
 			return false
 		} else {
 			val length = fmt.lineLengthBefore(node.offset) + lookahead.length
@@ -221,7 +221,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 		val lookahead = new FormattableDocument(fmt)
 		format(expression, lookahead)
 		val node = expression.nodeForEObject
-		if (node != null) {
+		if (node !== null) {
 			val textRegion = node.textRegion
 			lookahead.renderToString(textRegion.offset, textRegion.length)
 		} else {
@@ -250,7 +250,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 							format += head.prepend[increaseIndentation]
 						indented = true
 					}
-				} else if (node != null) {
+				} else if (node !== null) {
 					if (format.fitsIntoLine(arg)) {
 						format += node.append[oneSpace]
 					} else {
@@ -269,7 +269,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 			}
 		if (indented)
 			format += explicitParams.last.nodeForEObject.append[decreaseIndentation]
-		if (builder != null) {
+		if (builder !== null) {
 			format += builder.nodeForEObject.prepend [
 				if (builder.isMultilineLambda)
 					oneSpace
@@ -281,7 +281,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 	}
 
 	def protected XClosure builder(List<XExpression> params) {
-		if (params.last != null){
+		if (params.last !== null){
 			val grammarElement = (params.last.nodeForEObject as ICompositeNode).firstChild.grammarElement
 			if(grammarElement == XMemberFeatureCallAccess.memberCallArgumentsXClosureParserRuleCall_1_1_4_0 || 
 				grammarElement == XFeatureCallAccess.featureCallArgumentsXClosureParserRuleCall_4_0 ||
@@ -293,7 +293,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 
 	def protected Iterable<XExpression> explicitParams(List<XExpression> params) {
 		val builder = params.builder
-		if (builder != null) params.take(params.size - 1) else params
+		if (builder !== null) params.take(params.size - 1) else params
 	}
 
 	def protected void formatFeatureCallParamsMultiline(INode open, List<XExpression> params, FormattableDocument format) {
@@ -308,7 +308,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 				if (arg == explicitParams.head) {
 					val head = arg.nodeForEObject
 					format += head.prepend[newLine; increaseIndentation]
-				} else if (node != null)
+				} else if (node !== null)
 					format += node.append[newLine]
 				if (arg == explicitParams.last)
 					format += arg.nodeForEObject.append[newLine; decreaseIndentation]
@@ -316,7 +316,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 				node = arg.nodeForEObject.immediatelyFollowingKeyword(",")
 				format += node.prepend[noSpace]
 			}
-		if (builder != null) {
+		if (builder !== null) {
 			format += builder.nodeForEObject.prepend [
 				if (builder.isMultilineLambda)
 					oneSpace
@@ -333,7 +333,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 	 */
 	def protected boolean isMultilineLambda(XClosure closure) {
 		val closingBracket = closure.nodeForKeyword(']')
-		if (closingBracket?.hiddenLeafsBefore != null) {
+		if (closingBracket?.hiddenLeafsBefore !== null) {
 			return closingBracket.hiddenLeafsBefore.newLines > 0
 		}
 		return switch block : closure.expression {
@@ -398,7 +398,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 
 	def protected dispatch boolean isMultiParamInOwnLine(XMemberFeatureCall fc, FormattableDocument doc) {
 		val closingBracket = fc.nodeForKeyword(')')
-		if (closingBracket?.hiddenLeafsBefore != null) {
+		if (closingBracket?.hiddenLeafsBefore !== null) {
 			return closingBracket.hiddenLeafsBefore.newLines > 0
 		}
 		val params = fc.memberCallArguments.explicitParams
@@ -407,7 +407,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 
 	def protected dispatch boolean isMultiParamInOwnLine(XFeatureCall fc, FormattableDocument doc) {
 		val closingBracket = fc.nodeForKeyword(')')
-		if (closingBracket?.hiddenLeafsBefore != null) {
+		if (closingBracket?.hiddenLeafsBefore !== null) {
 			return closingBracket.hiddenLeafsBefore.newLines > 0
 		}
 		val params = fc.featureCallArguments.explicitParams
@@ -416,7 +416,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 
 	def protected dispatch boolean isMultiParamInOwnLine(XConstructorCall fc, FormattableDocument doc) {
 		val closingBracket = fc.nodeForKeyword(')')
-		if (closingBracket?.hiddenLeafsBefore != null) {
+		if (closingBracket?.hiddenLeafsBefore !== null) {
 			return closingBracket.hiddenLeafsBefore.newLines > 0
 		}
 		val params = fc.arguments.explicitParams
@@ -437,7 +437,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 			formatFeatureCallTypeParameters(call, format)
 			val featureNode = call.nodeForFeature(XABSTRACT_FEATURE_CALL__FEATURE)
 			val targetNode = call.memberCallTarget.nodeForEObject
-			if (targetNode != null) {
+			if (targetNode !== null) {
 				val callOffset = targetNode.endOffset
 				val op = call.nodeForKeyword(switch it: call {
 					case nullSafe: "?."
@@ -507,7 +507,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 
 	def protected AbstractRule binaryOperationPrecedence(EObject op) {
 		val node = op.nodeForFeature(XABSTRACT_FEATURE_CALL__FEATURE)
-		if (node != null && node.grammarElement instanceof CrossReference) {
+		if (node !== null && node.grammarElement instanceof CrossReference) {
 			val terminal = (node.grammarElement as CrossReference).terminal
 			if (terminal instanceof RuleCall)
 				return terminal.rule
@@ -516,7 +516,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 
 	def protected boolean isMultiline(XExpression expression, FormattableDocument doc) {
 		val node = expression.nodeForEObject
-		return node != null && {
+		return node !== null && {
 			val textRegion = node.textRegionWithLineInformation
 			textRegion.lineNumber != textRegion.endLineNumber
 		}
@@ -592,15 +592,15 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 			format += expr.nodeForKeyword("if").append[cfg(whitespaceBetweenKeywordAndParenthesisSL)]
 		if (expr.then instanceof XBlockExpression) {
 			format += thennode.prepend[cfg(bracesInNewLine)]
-			if (expr.^else != null)
+			if (expr.^else !== null)
 				format += thennode.append[cfg(bracesInNewLine)]
 		} else if (!multiline) {
 			format += thennode.prepend[oneSpace]
-			if (expr.^else != null)
+			if (expr.^else !== null)
 				format += thennode.append[oneSpace]
 		} else {
 			format += thennode.prepend[newLine increaseIndentation]
-			if (expr.^else != null)
+			if (expr.^else !== null)
 				format += thennode.append[newLine; decreaseIndentation]
 			else
 				format += thennode.append[decreaseIndentation]
@@ -615,7 +615,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 		}
 		expr.^if.format(format)
 		expr.then.format(format)
-		if (expr.^else != null)
+		if (expr.^else !== null)
 			expr.^else.format(format)
 	}
 
@@ -652,7 +652,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 		}
 		
 		val expression = expr.expression
-		if (expression != null) {
+		if (expression !== null) {
 			previousFormattedNode = expression.nodeForEObject => [format += prepend[oneSpace] format += append[noSpace]]
 			expression.format(format)
 		} else {
@@ -710,10 +710,10 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 
 	def protected dispatch void format(XBlockExpression expr, FormattableDocument format) {
 		val open = expr.nodeForKeyword("{")
-		if(expr.eContainer == null)
+		if(expr.eContainer === null)
 			format += open.prepend[noSpace]
 		val close = expr.nodeForKeyword("}")
-		if (open != null && close != null) {
+		if (open !== null && close !== null) {
 			val multiLine = !expr.isSingleLineBlock(format)
 			if (expr.expressions.empty) {
 				if(open.hiddenLeafsAfter.containsComment) {
@@ -733,10 +733,10 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 				}
 				for (child : expr.expressions) {
 					child.format(format)
-					if (child != expr.expressions.last || close != null) {
+					if (child != expr.expressions.last || close !== null) {
 						val childNode = child.nodeForEObject
 						val sem = childNode.immediatelyFollowingKeyword(";")
-						if (sem != null) {
+						if (sem !== null) {
 							format += sem.prepend[noSpace]
 							format += sem.append[if (multiLine) cfg(blankLinesAroundExpression) else oneSpace]
 						} else {
@@ -761,12 +761,12 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 		format += typeNode.prepend[noSpace]
 		format += typeNode.append[noSpace]
 		var node = typeNode
-		while (node != null) {
+		while (node !== null) {
 			node = node.immediatelyFollowingKeyword("[")
-			if (node != null) {
+			if (node !== null) {
 				format += node.append[noSpace]
 				node = node.immediatelyFollowingKeyword("]")
-				if (node != null) {
+				if (node !== null) {
 					format += node.append[noSpace]
 				}
 			}
@@ -795,14 +795,14 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 		expr.expression.format(format)
 		for (cc : expr.catchClauses) {
 			cc.format(format)
-			if (cc != expr.catchClauses.last || expr.finallyExpression != null) {
+			if (cc != expr.catchClauses.last || expr.finallyExpression !== null) {
 				if (cc.expression instanceof XBlockExpression)
 					format += cc.nodeForEObject.append[cfg(bracesInNewLine)]
 				else
 					format += cc.nodeForEObject.append[newLine]
 			}
 		}
-		if (expr.finallyExpression != null) {
+		if (expr.finallyExpression !== null) {
 			val fin = expr.finallyExpression.nodeForEObject
 			if (expr.finallyExpression instanceof XBlockExpression) {
 				format += fin.prepend[cfg(bracesInNewLine)]
@@ -829,7 +829,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 	}
 
 	def protected dispatch void format(JvmFormalParameter expr, FormattableDocument format) {
-		if (expr.parameterType != null)
+		if (expr.parameterType !== null)
 			format += expr.parameterType.nodeForEObject.append[oneSpace]
 		expr.parameterType.format(format)
 	}
@@ -844,7 +844,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 	def protected dispatch void format(XSwitchExpression expr, FormattableDocument format) {
 		val containsBlockExpr = expr.cases.exists[then instanceof XBlockExpression]
 		val switchSL = !containsBlockExpr && !expr.nodeForEObject.text.trim.contains("\n")
-		val caseSL = !containsBlockExpr && (!expr.cases.empty || expr.^default != null) && !expr.cases.exists[nodeForEObject.text.trim.contains("\n")] && !expr.^default?.nodeForEObject?.text?.contains("\n")
+		val caseSL = !containsBlockExpr && (!expr.cases.empty || expr.^default !== null) && !expr.cases.exists[nodeForEObject.text.trim.contains("\n")] && !expr.^default?.nodeForEObject?.text?.contains("\n")
 		val open = expr.nodeForKeyword("{")
 		val close = expr.nodeForKeyword("}")
 		format += expr.nodeForKeyword("switch").append[oneSpace]
@@ -852,7 +852,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 			format += open.prepend[oneSpace]
 			format += open.append[oneSpace]
 			for (c : expr.cases) {
-				if (c.then == null) {
+				if (c.then === null) {
 					format += c.nodeForEObject.append[oneSpace]
 				} else {
 					val cnode = c.then.nodeForEObject
@@ -860,7 +860,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 					format += cnode.append[oneSpace]
 				}
 			}
-			if(expr.^default != null) {
+			if(expr.^default !== null) {
 				format += expr.nodeForKeyword("default").append[noSpace]
 				format += expr.^default.nodeForEObject.surround[oneSpace]
 			}
@@ -875,7 +875,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 				if (c != expr.cases.last)
 					format += c.nodeForEObject.append[newLine]
 			}
-			if(expr.^default != null) {
+			if(expr.^default !== null) {
 				format += expr.nodeForKeyword("default").surround([newLine], [noSpace])
 				format += expr.^default.nodeForEObject.prepend[oneSpace]
 			}
@@ -883,14 +883,14 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 		} else {
 			format += open.prepend[cfg(bracesInNewLine)]
 			format += open.append[newLine]
-			if (!expr.cases.empty || expr.^default != null) {
+			if (!expr.cases.empty || expr.^default !== null) {
 				format += open.append[increaseIndentation]	
 			}
 			for (c : expr.cases) {
 				val cnode = c.then.nodeForEObject?:c.nodeForFeature(XCASE_PART__FALL_THROUGH)
 				if (c.then instanceof XBlockExpression) {
 					format += cnode.prepend[cfg(bracesInNewLine)]
-					if (expr.^default != null || c != expr.cases.last)
+					if (expr.^default !== null || c != expr.cases.last)
 						format += cnode.append[newLine]
 					else
 						format += cnode.append[newLine; decreaseIndentation]
@@ -900,13 +900,13 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 					} else {
 						format += cnode.prepend[newLine; increaseIndentation]
 					}
-					if (expr.^default != null || c != expr.cases.last)
+					if (expr.^default !== null || c != expr.cases.last)
 						format += cnode.append[newLine; decreaseIndentation]
 					else
 						format += cnode.append[newLine; decreaseIndentationChange = -2]
 				}
 			}
-			if(expr.^default != null) {
+			if(expr.^default !== null) {
 				format += expr.nodeForKeyword("default").append[noSpace]
 				if (expr.^default instanceof XBlockExpression) {
 					format += expr.^default.nodeForEObject.surround([cfg(bracesInNewLine)], [newLine; decreaseIndentation])
@@ -916,16 +916,16 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 			}
 		}
 		for (c : expr.cases) {
-			if (c.typeGuard != null && c.^case != null) {
+			if (c.typeGuard !== null && c.^case !== null) {
 				val typenode = c.nodeForFeature(XCASE_PART__TYPE_GUARD)
 				val casenode = c.nodeForFeature(XCASE_PART__CASE)
 				format += typenode.append[oneSpace]
 				format += casenode.prepend[oneSpace]
 				format += casenode.append[noSpace]
-			} else if (c.typeGuard != null) {
+			} else if (c.typeGuard !== null) {
 				val typenode = c.nodeForFeature(XCASE_PART__TYPE_GUARD)
 				format += typenode.append[noSpace]
-			} else if (c.^case != null) {
+			} else if (c.^case !== null) {
 				val casenode = c.nodeForFeature(XCASE_PART__CASE)
 				format += casenode.prepend[oneSpace]
 				format += casenode.append[noSpace]
@@ -933,7 +933,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 			c.^case.format(format)
 			c.then.format(format)
 		}
-		if(expr.^default != null)
+		if(expr.^default !== null)
 			expr.^default.format(format)
 	}
 
@@ -960,7 +960,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 		FormattableDocument format) {
 		formatClosureParameters(expr, format)
 		val explicit = expr.nodeForFeature(XCLOSURE__EXPLICIT_SYNTAX)
-		if (explicit != null) {
+		if (explicit !== null) {
 			if (expr.declaredFormalParameters.empty) {
 				format += explicit.prepend[noSpace]
 			} else {
@@ -1015,7 +1015,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 			c.format(format)
 			last = c.nodeForEObject
 			val semicolon = last.immediatelyFollowingKeyword(";")
-			if (semicolon != null) {
+			if (semicolon !== null) {
 				format += semicolon.prepend[noSpace]
 				last = semicolon
 			}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/annotations/formatting2/XbaseWithAnnotationsFormatter.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/annotations/formatting2/XbaseWithAnnotationsFormatter.xtend
@@ -19,7 +19,7 @@ class XbaseWithAnnotationsFormatter extends XbaseFormatter {
 	def dispatch void format(XAnnotation ann, extension IFormattableDocument document) {
 		ann.regionFor.keyword("@").append[noSpace]
 		ann.regionFor.keyword("(").surround[noSpace]
-		if (ann.value != null) {
+		if (ann.value !== null) {
 			ann.value.format
 			ann.regionFor.keyword(")").prepend[noSpace]
 		} else if (!ann.elementValuePairs.empty) {

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/annotations/validation/UnresolvedFeatureCallTypeAwareMessageProvider.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/annotations/validation/UnresolvedFeatureCallTypeAwareMessageProvider.xtend
@@ -85,7 +85,7 @@ class UnresolvedFeatureCallTypeAwareMessageProvider extends LinkingDiagnosticMes
 		val orField = !featureCall.isExplicitOperationCallOrBuilderSyntax()
 
 		var msg = '''The method «IF (orField)»or field «linkText»«ELSE»«linkText»(«args»)«ENDIF» is undefined'''
-		if (recieverType != null) {
+		if (recieverType !== null) {
 			msg += ''' for the type «recieverType.humanReadableName»'''
 		}
 		if (featureCall instanceof XFeatureCall && linkText.length() > 0 && Character.isUpperCase(linkText.charAt(0)) &&

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/DisableCodeGenerationAdapter.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/DisableCodeGenerationAdapter.xtend
@@ -18,18 +18,18 @@ class DisableCodeGenerationAdapter extends AdapterImpl {
 	}
 	
 	def static boolean isDisabled(JvmDeclaredType type) { 
-		getAdapter(type) != null
+		getAdapter(type) !== null
 	}
 	
 	def static void disableCodeGeneration(JvmDeclaredType declaredType) {
-		if (getAdapter(declaredType) == null) {
+		if (getAdapter(declaredType) === null) {
 			declaredType.eAdapters.add(new DisableCodeGenerationAdapter)
 		}
 	}
 	
 	def static void enableCodeGeneration(JvmDeclaredType declaredType) {
 		val adapter = getAdapter(declaredType)
-		if (adapter != null) {
+		if (adapter !== null) {
 			declaredType.eAdapters.remove(adapter)
 		}
 	}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/ErrorSafeExtensions.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/ErrorSafeExtensions.xtend
@@ -99,7 +99,7 @@ class ErrorSafeExtensions {
 	}
 	
 	def void serializeSafely(JvmTypeReference typeRef, String surrogateType, ITreeAppendable appendable) {
-		if(typeRef == null || typeRef.type == null) {
+		if(typeRef === null || typeRef.type === null) {
 			switch(typeRef) {
 				JvmSpecializedTypeReference: typeRef.equivalent.serializeSafely(surrogateType, appendable)
 				JvmUnknownTypeReference: appendable.append(typeRef.qualifiedName)
@@ -117,7 +117,7 @@ class ErrorSafeExtensions {
 					serialize(typeRef, typeRef.eContainer, errorChild)
 				} catch(Exception ignoreMe) {}
 				appendable.closeErrorAppendable(errorChild)
-				if(surrogateType != null) 
+				if(surrogateType !== null) 
 					appendable.append(surrogateType)
 			} else {
 				serialize(typeRef, typeRef.eContainer, appendable)
@@ -126,7 +126,7 @@ class ErrorSafeExtensions {
 	}
 	
 	def void serializeSafely(JvmAnnotationReference annotationRef, ITreeAppendable appendable, (ITreeAppendable)=>void onSuccess) {
-		if(annotationRef == null || annotationRef.annotation == null) {
+		if(annotationRef === null || annotationRef.annotation === null) {
 			val errorChild = appendable.openErrorAppendable(appendable)
 			errorChild.append("annotation is 'null'")
 			appendable.closeErrorAppendable(errorChild)

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.xtend
@@ -126,7 +126,7 @@ class JvmModelGenerator implements IGenerator {
 	def dispatch void internalDoGenerate(JvmDeclaredType type, IFileSystemAccess fsa) {
 		if (DisableCodeGenerationAdapter.isDisabled(type))
 			return;
-		if(type.qualifiedName != null)
+		if(type.qualifiedName !== null)
 			fsa.generateFile(type.qualifiedName.replace('.', '/') + '.java', type.generateType(generatorConfigProvider.get(type)))
 	}
 	
@@ -143,7 +143,7 @@ class JvmModelGenerator implements IGenerator {
 		bodyAppendable.closeScope
 		val importAppendable = createAppendable(type, importManager, config)
         generateFileHeader(type, importAppendable, config)
-		if (type.packageName != null) {
+		if (type.packageName !== null) {
 			importAppendable.append("package ").append(type.packageName).append(";");
 			importAppendable.newLine.newLine
 		}
@@ -197,7 +197,7 @@ class JvmModelGenerator implements IGenerator {
 	def generateAnnotationsWithSyntheticSuppressWarnings(JvmDeclaredType it, ITreeAppendable appendable, GeneratorConfig config) {
 		val noSuppressWarningsFilter = [JvmAnnotationReference it | annotation?.identifier != SuppressWarnings.name]
 		annotations.filter(noSuppressWarningsFilter).generateAnnotations(appendable, true, config)
-		if (it.eContainer == null)
+		if (it.eContainer === null)
 			appendable.append('''@SuppressWarnings("all")''').newLine
 	}
 
@@ -274,25 +274,25 @@ class JvmModelGenerator implements IGenerator {
 	}
 
 	def void generateDefaultExpression(JvmOperation it, ITreeAppendable appendable, GeneratorConfig config) {
-		if (compilationStrategy != null) {
+		if (compilationStrategy !== null) {
 			appendable.append(" default ")
 			appendable.increaseIndentation
 			compilationStrategy.apply(appendable)
 			appendable.decreaseIndentation
-		} else if (compilationTemplate != null) {
+		} else if (compilationTemplate !== null) {
 			appendable.append(" default ").increaseIndentation
 			appendCompilationTemplate(appendable, it)
 			appendable.decreaseIndentation
 		} else if (config.generateExpressions) {
 			val body = associatedExpression
-			if(body != null) {
+			if(body !== null) {
 				if(body.hasErrors()) {
 					appendable.append("/* skipped default expression with errors */")
 				} else {
 					appendable.append(" default ")
 					compiler.compileAsJavaExpression(body, appendable, returnType)
 				}
-			} else if (defaultValue != null) {
+			} else if (defaultValue !== null) {
 				if(defaultValue.hasErrors()) {
 					appendable.append("/* skipped default expression with errors */")
 				} else {
@@ -382,7 +382,7 @@ class JvmModelGenerator implements IGenerator {
 	 * Returns the visibility modifier and a space as suffix if not empty
 	 */
 	def javaName(JvmVisibility visibility) {
-		if (visibility != null)
+		if (visibility !== null)
 			return switch visibility {
 					case JvmVisibility.PRIVATE : 'private '
 					case JvmVisibility.PUBLIC : 'public '
@@ -410,7 +410,7 @@ class JvmModelGenerator implements IGenerator {
 			val withoutObject = superTypes.filter [ typeRef | typeRef.identifier != implicitSuperType ]
 			val superClazz = withoutObject.filter(typeRef | typeRef.type instanceof JvmGenericType && !(typeRef.type as JvmGenericType).isInterface).head
 			val superInterfaces = withoutObject.filter(typeRef | typeRef != superClazz)
-			if (superClazz != null) {
+			if (superClazz !== null) {
 				val hasErrors = superClazz.hasErrors()
 				if(hasErrors) 
 					appendable.append('/* ')
@@ -468,7 +468,7 @@ class JvmModelGenerator implements IGenerator {
 		annotations.generateAnnotations(tracedAppendable, true, config)
 		generateModifier(tracedAppendable, config)
 		generateTypeParameterDeclaration(tracedAppendable, config)
-		if (returnType == null) {
+		if (returnType === null) {
 			tracedAppendable.append("void")
 		} else {
 			returnType.serializeSafely("Object", tracedAppendable)
@@ -509,7 +509,7 @@ class JvmModelGenerator implements IGenerator {
 	}
 	
 	def void generateInitialization(JvmField it, ITreeAppendable appendable, GeneratorConfig config) {
-		if (compilationStrategy != null) {
+		if (compilationStrategy !== null) {
 			val errors = directErrorsOrLogicallyContainedErrors
 			if (errors.isEmpty) {
 				appendable.append(" = ")
@@ -519,7 +519,7 @@ class JvmModelGenerator implements IGenerator {
 			} else {
 				appendable.append(" /* Skipped initializer because of errors */")
 			}
-		} else if (compilationTemplate != null) {
+		} else if (compilationTemplate !== null) {
 			val errors = directErrorsOrLogicallyContainedErrors
 			if (errors.isEmpty) {
 				appendable.append(" = ").increaseIndentation
@@ -530,7 +530,7 @@ class JvmModelGenerator implements IGenerator {
 			}
 		} else {
 			val expression = associatedExpression
-			if (expression != null && config.generateExpressions) {
+			if (expression !== null && config.generateExpressions) {
 				if(expression.hasErrors()) {
 					appendable.append(" /* Skipped initializer because of errors */")
 				} else {
@@ -606,7 +606,7 @@ class JvmModelGenerator implements IGenerator {
 	}
 	
 	def hasBody(JvmExecutable it) {
-		compilationTemplate != null || compilationStrategy != null || associatedExpression != null
+		compilationTemplate !== null || compilationStrategy !== null || associatedExpression !== null
 	}
 	
 	/**
@@ -618,7 +618,7 @@ class JvmModelGenerator implements IGenerator {
 		var errors = feature.errors
 		if(errors.empty) {
 			val expression = feature.associatedExpression
-			if (expression != null) {
+			if (expression !== null) {
 				errors = expression.errors
 			}
 		}
@@ -626,7 +626,7 @@ class JvmModelGenerator implements IGenerator {
 	}
 
 	def void generateExecutableBody(JvmExecutable op, ITreeAppendable appendable, GeneratorConfig config) {
-		if (op.compilationStrategy != null) {
+		if (op.compilationStrategy !== null) {
 			var errors = op.directErrorsOrLogicallyContainedErrors
 			if(errors.empty) {
 				appendable.increaseIndentation.append("{").newLine
@@ -635,7 +635,7 @@ class JvmModelGenerator implements IGenerator {
 			} else {
 				generateBodyWithIssues(appendable, errors)
 			}
-		} else if (op.compilationTemplate != null) {
+		} else if (op.compilationTemplate !== null) {
 			val errors = op.directErrorsOrLogicallyContainedErrors
 			if(errors.empty) {
 				appendable.increaseIndentation.append("{").newLine
@@ -646,7 +646,7 @@ class JvmModelGenerator implements IGenerator {
 			}
 		} else {
 			val expression = op.getAssociatedExpression
-			if (expression != null && config.generateExpressions) {
+			if (expression !== null && config.generateExpressions) {
 				val errors = expression.errors
 				if(errors.empty) {
 					val returnType = switch(op) { 
@@ -716,7 +716,7 @@ class JvmModelGenerator implements IGenerator {
 				}
 			}
 		}
-		if (superType != null)
+		if (superType !== null)
 			b.declareVariable(superType, 'super');
 	}
 	
@@ -732,7 +732,7 @@ class JvmModelGenerator implements IGenerator {
 				}
 			}
 		}
-		if (declaredType != null)
+		if (declaredType !== null)
 			b.declareVariable(declaredType, 'this');
 	}
 
@@ -779,13 +779,13 @@ class JvmModelGenerator implements IGenerator {
 		for(node : documentationNodes){
 			for(region : javaDocTypeReferenceProvider.computeTypeRefRegions(node)) {
 				val text = region.text
-				if(text != null && text.length > 0){
+				if(text !== null && text.length > 0){
 					val fqn = qualifiedNameConverter.toQualifiedName(text)
 					val context = NodeModelUtils.findActualSemanticObjectFor(node)
-					if(fqn.segmentCount == 1 && context != null){
+					if(fqn.segmentCount == 1 && context !== null){
 						val scope = scopeProvider.getScope(context, JVM_PARAMETERIZED_TYPE_REFERENCE__TYPE)
 						val candidate = scope.getSingleElement(fqn)
-						if(candidate != null) {
+						if(candidate !== null) {
 							val jvmType = 	(
 											if(candidate.EObjectOrProxy.eIsProxy)
 												EcoreUtil.resolve(candidate.EObjectOrProxy, context)
@@ -856,8 +856,8 @@ class JvmModelGenerator implements IGenerator {
 	}
 	 
 	def void toJava(JvmAnnotationValue it, ITreeAppendable appendable, GeneratorConfig config) {
-		if (operation != null) {
-			if (operation.simpleName == null) {
+		if (operation !== null) {
+			if (operation.simpleName === null) {
 				return
 			}
 			appendable.append(operation.simpleName);
@@ -981,7 +981,7 @@ class JvmModelGenerator implements IGenerator {
 	}
 	
 	def JvmGenericType containerType(EObject context) {
-		if(context == null) 
+		if(context === null) 
 			null
 		else if(context instanceof JvmGenericType)
 			context
@@ -989,7 +989,7 @@ class JvmModelGenerator implements IGenerator {
 	}
 	
 	def protected String makeJavaIdentifier(String name) {
-		if (name == null) {
+		if (name === null) {
 			return "__unknown__";
 		} else if (keywords.isJavaKeyword(name)) {
 			name+"_"

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/TreeAppendableUtil.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/TreeAppendableUtil.xtend
@@ -45,7 +45,7 @@ class TreeAppendableUtil {
 				ILocationInFileProviderExtension: locationProvider.getTextRegion(source, ILocationInFileProviderExtension.RegionDescription.INCLUDING_COMMENTS)
 				default: locationProvider.getFullTextRegion(source)
 			} as ITextRegionWithLineInformation
-			if (it != null && it !== ITextRegion.EMPTY_REGION)
+			if (it !== null && it !== ITextRegion.EMPTY_REGION)
 				appendable.trace(new LocationData(offset, length, lineNumber, endLineNumber, null))
 			else
 				appendable

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/controlflow/ConstantConditionsInterpreter.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/controlflow/ConstantConditionsInterpreter.xtend
@@ -115,7 +115,7 @@ class ConstantConditionsInterpreter {
 
 	def dispatch EvaluationResult internalEvaluate(XAbstractFeatureCall it, EvaluationContext context) {
 		val feature = getFeature(it, context)
-		if (feature == null || feature.eIsProxy) {
+		if (feature === null || feature.eIsProxy) {
 			return EvaluationResult.NOT_A_CONSTANT
 		}
 		switch feature {
@@ -132,13 +132,13 @@ class ConstantConditionsInterpreter {
 						return new EvaluationResult(feature.constantValue, true)
 					}
 				} else if (feature.final) {
-					if (actualReceiver != null) {
+					if (actualReceiver !== null) {
 						val receiver = doEvaluate(actualReceiver, context)
 						if (receiver.notAConstant) {
 							return receiver
 						}
 						val associatedExpression = feature.associatedExpression
-						if (associatedExpression != null) {
+						if (associatedExpression !== null) {
 							val result = associatedExpression.evaluateAssociatedExpression(context)
 							if (result.rawValue instanceof ThisReference)
 								return EvaluationResult.NOT_A_CONSTANT
@@ -154,7 +154,7 @@ class ConstantConditionsInterpreter {
 						}
 					} else {
 						val associatedExpression = feature.associatedExpression
-						if (associatedExpression != null) {
+						if (associatedExpression !== null) {
 							val result = associatedExpression.evaluateAssociatedExpression(context)
 							return new EvaluationResult(result.rawValue, false)
 						} else {
@@ -163,12 +163,12 @@ class ConstantConditionsInterpreter {
 					}
 				}
 			}
-			XVariableDeclaration case !feature.writeable && feature.right != null: {
+			XVariableDeclaration case !feature.writeable && feature.right !== null: {
 				return feature.right.evaluateAssociatedExpression(context)
 			}
 			JvmFormalParameter: {
 				switch container : feature.eContainer {
-					XSwitchExpression case container.^switch != null: {
+					XSwitchExpression case container.^switch !== null: {
 						return container.^switch.doEvaluate(context)
 					}
 					default: return new EvaluationResult(feature, false)
@@ -180,7 +180,7 @@ class ConstantConditionsInterpreter {
 	
 	def getFeature(XAbstractFeatureCall call, EvaluationContext context) {
 		var feature = call.eGet(XbasePackage.Literals.XABSTRACT_FEATURE_CALL__FEATURE, false) as JvmIdentifiableElement
-		if (feature == null || feature.eIsProxy) {
+		if (feature === null || feature.eIsProxy) {
 			feature = context.resolvedTypes.getLinkedFeature(call)
 		}
 		return feature
@@ -239,7 +239,7 @@ class ConstantConditionsInterpreter {
 	}
 	
 	def dispatch EvaluationResult internalEvaluate(XBinaryOperation it, EvaluationContext context) {
-		if (isFromXbaseLibrary(context) && rightOperand != null) {
+		if (isFromXbaseLibrary(context) && rightOperand !== null) {
 			val left = leftOperand.doEvaluate(context) 
 			val right = rightOperand.doEvaluate(context)
 			try {

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/controlflow/DefaultEarlyExitComputer.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/controlflow/DefaultEarlyExitComputer.xtend
@@ -43,11 +43,11 @@ import org.eclipse.xtext.xbase.XWhileExpression
 	}
 
 	def protected boolean isNotEmpty(Collection<ExitPoint> exitPoints) {
-		return exitPoints != null && !exitPoints.isEmpty()
+		return exitPoints !== null && !exitPoints.isEmpty()
 	}
 
 	@Override override Collection<ExitPoint> getExitPoints(XExpression expression) {
-		if(expression == null) return Collections.emptyList()
+		if(expression === null) return Collections.emptyList()
 		return exitPoints(expression)
 	}
 
@@ -87,7 +87,7 @@ import org.eclipse.xtext.xbase.XWhileExpression
 		if (isNotEmpty(exitPoints)) {
 			return exitPoints
 		}
-		if (predicate == null || isBooleanConstant(predicate, true)) {
+		if (predicate === null || isBooleanConstant(predicate, true)) {
 			exitPoints = getExitPoints(expression.getEachExpression())
 			if(isNotEmpty(exitPoints)) return exitPoints
 			for (XExpression child : expression.getUpdateExpressions()) {
@@ -155,7 +155,7 @@ import org.eclipse.xtext.xbase.XWhileExpression
 		for (XCasePart casePart : expression.getCases()) {
 			// TODO do we have an early exit if the first case condition is an early exit?
 			var XExpression then = casePart.getThen()
-			if (then != null) {
+			if (then !== null) {
 				var Collection<ExitPoint> caseExit = getExitPoints(then)
 				if(!isNotEmpty(caseExit)) return Collections.emptyList() else result.addAll(caseExit)
 			}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/SeparatorRegions.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/SeparatorRegions.xtend
@@ -25,7 +25,7 @@ import org.eclipse.xtext.formatting2.regionaccess.internal.TextSegment
 	def void prepend(T object) {
 		val newObject = new ObjectEntry<T, R>(this)
 		newObject.object = object
-		if (first == null) {
+		if (first === null) {
 			first = newObject
 		} else {
 			newObject.next = first.leadingSeparator
@@ -41,7 +41,7 @@ import org.eclipse.xtext.formatting2.regionaccess.internal.TextSegment
 		newSeparator.separator = separator
 		newObject.previous = newSeparator
 		newSeparator.next = newObject
-		if (first == null) {
+		if (first === null) {
 			first = newObject
 		} else {
 			newObject.next = first.leadingSeparator
@@ -53,13 +53,13 @@ import org.eclipse.xtext.formatting2.regionaccess.internal.TextSegment
 	def void appendWithTrailingSeparator(T object, R separator) {
 		val newObject = new ObjectEntry<T, R>(this)
 		newObject.object = object
-		if (separator != null) {
+		if (separator !== null) {
 			val newSeparator = new SeparatorEntry<T, R>
 			newSeparator.separator = separator
 			newObject.next = newSeparator
 			newSeparator.previous = newObject
 		}
-		if (first == null) {
+		if (first === null) {
 			first = newObject
 		} else {
 			val last = separators.last
@@ -73,7 +73,7 @@ import org.eclipse.xtext.formatting2.regionaccess.internal.TextSegment
 			ObjectEntry<T, R> next = SeparatorRegions.this.first
 
 			override protected computeNext() {
-				if (next == null)
+				if (next === null)
 					return endOfData()
 				val current = next
 				next = next.trailingObject
@@ -89,7 +89,7 @@ import org.eclipse.xtext.formatting2.regionaccess.internal.TextSegment
 					SeparatorEntry<T, R> next = SeparatorRegions.this.first.trailingSeparator
 
 					override protected computeNext() {
-						if (next == null)
+						if (next === null)
 							return endOfData()
 						val current = next
 						next = next.trailingSeparator
@@ -101,10 +101,10 @@ import org.eclipse.xtext.formatting2.regionaccess.internal.TextSegment
 	}
 
 	override toString() {
-		if (first != null) {
+		if (first !== null) {
 			val list = newArrayList()
 			var Entry<T, R> current = first.leadingSeparator
-			while (current != null) {
+			while (current !== null) {
 				list += current.toString
 				current = current.next
 			}
@@ -142,8 +142,8 @@ import org.eclipse.xtext.formatting2.regionaccess.internal.TextSegment
 	def ITextSegment getRegion() {
 		val prev = leadingSeparator
 		val trail = trailingSeparator
-		val offset = if(prev != null) prev.separator.endOffset else list.root.offset
-		val endOffset = if(trail != null) trail.separator.offset else list.root.endOffset
+		val offset = if(prev !== null) prev.separator.endOffset else list.root.offset
+		val endOffset = if(trail !== null) trail.separator.offset else list.root.endOffset
 		return new TextSegment(list.root.textRegionAccess, offset, endOffset - offset)
 	}
 

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.xtend
@@ -75,7 +75,7 @@ class XbaseFormatter extends XtypeFormatter {
 		ISemanticRegion close,
 		extension IFormattableDocument format
 	) {
-		if (close == null || open == null) {
+		if (close === null || open === null) {
 			// broken, do nothing
 		} else if (elements.empty) {
 			open.append[noSpace]
@@ -96,7 +96,7 @@ class XbaseFormatter extends XtypeFormatter {
 			for (ele : items) {
 				val sep = ele.leadingSeparator?.separator
 				if (ele.object.prependNewLineIfMultiline) {
-					if (sep == null)
+					if (sep === null)
 						open.append[noSpace; autowrap(ele.region.length); onAutowrap = indent]
 					else
 						sep.append[oneSpace; autowrap(ele.region.length); onAutowrap = indent]
@@ -155,7 +155,7 @@ class XbaseFormatter extends XtypeFormatter {
 	}
 
 	def protected void formatBuilderWithLeadingGap(XClosure closure, extension IFormattableDocument format) {
-		if (closure != null) {
+		if (closure !== null) {
 			val offset = closure.previousHiddenRegion.offset
 			val length = closure.nextHiddenRegion.offset - offset
 			formatConditionally(offset, length, [ doc |
@@ -170,7 +170,7 @@ class XbaseFormatter extends XtypeFormatter {
 	}
 
 	def protected XClosure builder(List<XExpression> params) {
-		if (params.last != null) {
+		if (params.last !== null) {
 			val grammarElement = params.last.grammarElement
 			if (grammarElement == XMemberFeatureCallAccess.memberCallArgumentsXClosureParserRuleCall_1_1_4_0 ||
 				grammarElement == XFeatureCallAccess.featureCallArgumentsXClosureParserRuleCall_4_0 ||
@@ -181,7 +181,7 @@ class XbaseFormatter extends XtypeFormatter {
 
 	def protected Iterable<XExpression> explicitParams(List<XExpression> params) {
 		val builder = params.builder
-		if(builder != null) params.take(params.size - 1) else params
+		if(builder !== null) params.take(params.size - 1) else params
 	}
 
 	def dispatch void format(XConstructorCall expr, extension IFormattableDocument format) {
@@ -239,7 +239,7 @@ class XbaseFormatter extends XtypeFormatter {
 			val operator = entry.leadingSeparator.separator
 			formatFeatureCallTypeParameters(call, format)
 			val feature = call.regionFor.feature(XABSTRACT_FEATURE_CALL__FEATURE)
-			if (feature != null) {
+			if (feature !== null) {
 				val autowrapLength = Math.min(entry.region.length, feature.length * 2)
 				operator.prepend[noSpace].append[noSpace; autowrap(autowrapLength) onAutowrap = indentOnce]
 				if (call.explicitOperationCall) {
@@ -255,7 +255,7 @@ class XbaseFormatter extends XtypeFormatter {
 
 	def protected AbstractRule binaryOperationPrecedence(EObject op) {
 		val node = op.regionFor.feature(XABSTRACT_FEATURE_CALL__FEATURE)
-		if (node != null && node.grammarElement instanceof RuleCall) {
+		if (node !== null && node.grammarElement instanceof RuleCall) {
 			return (node.grammarElement as RuleCall).rule
 		}
 	}
@@ -317,7 +317,7 @@ class XbaseFormatter extends XtypeFormatter {
 		else
 			expr.regionFor.keyword("if").append(whitespaceBetweenKeywordAndParenthesisSL)
 		expr.^if.format
-		if (expr.^else == null) {
+		if (expr.^else === null) {
 			expr.then.formatBody(multiline, format)
 		} else {
 			expr.then.formatBodyInline(multiline, format)
@@ -366,9 +366,9 @@ class XbaseFormatter extends XtypeFormatter {
 	def dispatch void format(XBlockExpression expr, extension IFormattableDocument format) {
 		val open = expr.regionFor.keyword("{")
 		val close = expr.regionFor.keyword("}")
-		if (expr.eContainer == null)
+		if (expr.eContainer === null)
 			expr.surround[noSpace]
-		if (open != null && close != null) {
+		if (open !== null && close !== null) {
 			if (expr.isSingleLineBlock) {
 				expr.formatConditionally(
 					[ f |
@@ -409,7 +409,7 @@ class XbaseFormatter extends XtypeFormatter {
 		for (cc : expr.catchClauses) {
 			cc.regionFor.keyword("catch").append(whitespaceBetweenKeywordAndParenthesisML)
 			cc.declaredParam.prepend[noSpace].append[noSpace].format
-			if (cc != expr.catchClauses.last || expr.finallyExpression != null)
+			if (cc != expr.catchClauses.last || expr.finallyExpression !== null)
 				cc.expression.formatBodyInline(true, format)
 			else
 				cc.expression.formatBody(true, format)
@@ -432,7 +432,7 @@ class XbaseFormatter extends XtypeFormatter {
 	def dispatch void format(XSwitchExpression expr, extension IFormattableDocument format) {
 		val containsBlockExpr = expr.cases.exists[then instanceof XBlockExpression]
 		val switchSL = !containsBlockExpr && !expr.multiline
-		val caseSL = !containsBlockExpr && (!expr.cases.empty || expr.^default != null) &&
+		val caseSL = !containsBlockExpr && (!expr.cases.empty || expr.^default !== null) &&
 			!expr.cases.exists[multiline] && !expr.^default.multilineOrInNewLine
 		val open = expr.regionFor.keyword("{")
 		val close = expr.regionFor.keyword("}")
@@ -443,13 +443,13 @@ class XbaseFormatter extends XtypeFormatter {
 			for (c : expr.cases) {
 				c.^case.format
 				c.then.format
-				if (c.then == null) {
+				if (c.then === null) {
 					c.append[oneSpace]
 				} else {
 					c.then.prepend[oneSpace].append[oneSpace]
 				}
 			}
-			if (expr.^default != null) {
+			if (expr.^default !== null) {
 				expr.regionFor.keyword("default").append[noSpace]
 				expr.^default.surround[oneSpace].format
 			}
@@ -466,14 +466,14 @@ class XbaseFormatter extends XtypeFormatter {
 				if (c != expr.cases.last)
 					c.append[newLine]
 			}
-			if (expr.^default != null) {
+			if (expr.^default !== null) {
 				expr.regionFor.keyword("default").prepend[newLine].append[noSpace]
 				expr.^default.prepend[oneSpace].format
 			}
 			close.prepend[newLine]
 		} else {
 			open.prepend(bracesInNewLine).append[newLine]
-			if (!expr.cases.empty || expr.^default != null) {
+			if (!expr.cases.empty || expr.^default !== null) {
 				interior(open, close)[indent]
 			}
 			for (c : expr.cases) {
@@ -481,18 +481,18 @@ class XbaseFormatter extends XtypeFormatter {
 				c.then.formatBodyParagraph(format)
 				c.regionFor.feature(XCASE_PART__FALL_THROUGH).prepend[noSpace].append[newLine]
 			}
-			if (expr.^default != null) {
+			if (expr.^default !== null) {
 				expr.regionFor.keyword("default").append[noSpace]
 				expr.^default.formatBodyParagraph(format)
 			}
 		}
 		for (c : expr.cases) {
-			if (c.typeGuard != null && c.^case != null) {
+			if (c.typeGuard !== null && c.^case !== null) {
 				c.typeGuard.append[oneSpace]
 				c.^case.prepend[oneSpace].append[noSpace]
-			} else if (c.typeGuard != null) {
+			} else if (c.typeGuard !== null) {
 				c.typeGuard.append[noSpace]
-			} else if (c.^case != null) {
+			} else if (c.^case !== null) {
 				c.^case.prepend[oneSpace].append[noSpace]
 			}
 		}
@@ -525,7 +525,7 @@ class XbaseFormatter extends XtypeFormatter {
 			XBlockExpression: x.expressions
 			default: newArrayList(x)
 		}
-		if (open == null || close == null) {
+		if (open === null || close === null) {
 			// broken, do nothing
 		} else if (children.empty) {
 			if (open.nextHiddenRegion.containsComment)
@@ -545,7 +545,7 @@ class XbaseFormatter extends XtypeFormatter {
 				for (c : children) {
 					c.format
 					val semicolon = c.immediatelyFollowing.keyword(";")
-					if (semicolon != null)
+					if (semicolon !== null)
 						semicolon.prepend[noSpace].append[if(c == children.last) noSpace else oneSpace]
 					else
 						c.append[if(c == children.last) noSpace else oneSpace]
@@ -558,7 +558,7 @@ class XbaseFormatter extends XtypeFormatter {
 	}
 
 	def protected void formatBody(XExpression expr, boolean forceMultiline, extension IFormattableDocument doc) {
-		if (expr == null)
+		if (expr === null)
 			return;
 		if (expr instanceof XBlockExpression) {
 			expr.prepend(bracesInNewLine)
@@ -571,7 +571,7 @@ class XbaseFormatter extends XtypeFormatter {
 	}
 
 	def protected void formatBodyInline(XExpression expr, boolean forceMultiline, extension IFormattableDocument doc) {
-		if (expr == null)
+		if (expr === null)
 			return;
 		if (expr instanceof XBlockExpression) {
 			expr.prepend(bracesInNewLine).append(bracesInNewLine)
@@ -584,7 +584,7 @@ class XbaseFormatter extends XtypeFormatter {
 	}
 
 	def protected void formatBodyParagraph(XExpression expr, extension IFormattableDocument doc) {
-		if (expr == null)
+		if (expr === null)
 			return;
 		if (expr instanceof XBlockExpression) {
 			expr.prepend(bracesInNewLine).append[newLine]
@@ -621,7 +621,7 @@ class XbaseFormatter extends XtypeFormatter {
 			for (child : expressions) {
 				child.format
 				val sem = child.immediatelyFollowing.keyword(";")
-				if (sem != null)
+				if (sem !== null)
 					sem.prepend[noSpace].append(blankLinesAroundExpression)
 				else
 					child.append(blankLinesAroundExpression)
@@ -638,7 +638,7 @@ class XbaseFormatter extends XtypeFormatter {
 			for (child : expressions) {
 				child.format
 				val sem = child.immediatelyFollowing.keyword(";")
-				if (sem != null)
+				if (sem !== null)
 					sem.prepend[noSpace].append[oneSpace]
 				else
 					child.append[oneSpace]
@@ -647,7 +647,7 @@ class XbaseFormatter extends XtypeFormatter {
 	}
 
 	def protected boolean isMultilineOrInNewLine(EObject obj) {
-		obj != null && (obj.multiline || obj.previousHiddenRegion.multiline)
+		obj !== null && (obj.multiline || obj.previousHiddenRegion.multiline)
 	}
 
 }

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/ImportsCollector.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/ImportsCollector.xtend
@@ -47,7 +47,7 @@ class ImportsCollector {
 			val nodeRegion = node.totalTextRegion
 			if (selectedRegion.contains(nodeRegion)) {
 				val semanticElement = node.semanticElement
-				if (semanticElement != null) {
+				if (semanticElement !== null) {
 					visit(semanticElement, NodeModelUtils.findActualNodeFor(semanticElement), acceptor)
 				}
 			}
@@ -63,7 +63,7 @@ class ImportsCollector {
 		var EObject semanticElementOffset = leafNodeAtOffset.getSemanticElement()
 		var ICompositeNode actualOffsetNode = NodeModelUtils.findActualNodeFor(semanticElementOffset)
 		val endOffset = textRegion.offset + textRegion.length
-		while (actualOffsetNode.getParent() != null && actualOffsetNode.getTotalEndOffset() < endOffset) {
+		while (actualOffsetNode.getParent() !== null && actualOffsetNode.getTotalEndOffset() < endOffset) {
 			actualOffsetNode = actualOffsetNode.getParent()
 		}
 		val actualSemanticObj = actualOffsetNode.semanticElement
@@ -113,20 +113,20 @@ class ImportsCollector {
 	}
 
 	dispatch def void visit(JvmDeclaredType jvmType, INode originNode, ImportsAcceptor acceptor) {
-		if (jvmType.getDeclaringType() == null) {
+		if (jvmType.getDeclaringType() === null) {
 			collectTypeImportFrom(jvmType, acceptor)
 		}
 		val text = NodeModelUtils.getTokenText(originNode);
 		val outerSegment = getFirstNameSegment(text);
 		val outerType = findDeclaringTypeBySimpleName(jvmType, outerSegment);
-		if (outerType == null) {
+		if (outerType === null) {
 			throw new IllegalStateException();
 		}
 		collectTypeImportFrom(outerType, acceptor)
 	}
 
 	def private JvmDeclaredType findDeclaringTypeBySimpleName(JvmDeclaredType referencedType, String outerSegment) {
-		if (referencedType.getDeclaringType() == null || outerSegment.equals(referencedType.getSimpleName())) {
+		if (referencedType.getDeclaringType() === null || outerSegment.equals(referencedType.getSimpleName())) {
 			return referencedType
 		}
 		return findDeclaringTypeBySimpleName(referencedType.getDeclaringType(), outerSegment)
@@ -207,7 +207,7 @@ class ImportsCollector {
 					TypesPackage.Literals.JVM_PARAMETERIZED_TYPE_REFERENCE__TYPE)
 				var IEObjectDescription singleElement = scope.getSingleElement(QualifiedName.create(docTypeText))
 				var JvmType referencedType = null
-				if (singleElement != null) {
+				if (singleElement !== null) {
 					referencedType = singleElement.getEObjectOrProxy() as JvmType
 				}
 				if (referencedType instanceof JvmDeclaredType && !referencedType.eIsProxy()) {

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/StaticallyImportedMemberProvider.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/StaticallyImportedMemberProvider.xtend
@@ -33,14 +33,14 @@ class StaticallyImportedMemberProvider {
 
 	def findAllFeatures(XImportDeclaration it) {
 		val importedType = importedType
-		if (!static || importedType == null) {
+		if (!static || importedType === null) {
 			return <JvmFeature>emptyList
 		}
 		val visibilityHelper = eResource.visibilityHelper
 		val resolvedFeatures = importedType.resolvedFeatures
 		resolvedFeatures.allFeatures.filter [ feature |
 			feature.static && visibilityHelper.isVisible(feature) &&
-			(memberName == null || feature.simpleName.startsWith(memberName))
+			(memberName === null || feature.simpleName.startsWith(memberName))
 		]
 	}
 
@@ -49,7 +49,7 @@ class StaticallyImportedMemberProvider {
 	}
 
 	def getAllFeatures(Resource resource, JvmDeclaredType importedType, boolean ^static, boolean ^extension, String memberName) {
-		if (!static || importedType == null) {
+		if (!static || importedType === null) {
 			return <JvmFeature>emptyList
 		}
 		val visibilityHelper = resource.visibilityHelper
@@ -63,7 +63,7 @@ class StaticallyImportedMemberProvider {
 		switch resource {
 			XtextResource: {
 				val packageName = resource.packageName
-				if (packageName == null) {
+				if (packageName === null) {
 					visibilityHelper
 				} else {
 					new ContextualVisibilityHelper(visibilityHelper, packageName)

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/interpreter/AbstractConstantExpressionsInterpreter.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/interpreter/AbstractConstantExpressionsInterpreter.xtend
@@ -87,7 +87,7 @@ class AbstractConstantExpressionsInterpreter {
 	}
 
 	protected def toTypeReference(JvmType type, int arrayDimensions) {
-		if (type == null)
+		if (type === null)
 			return null
 		var JvmTypeReference resultTypeRef = TypesFactory.eINSTANCE.createJvmParameterizedTypeReference => [
 			it.type = type

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/interpreter/SwitchConstantExpressionsInterpreter.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/interpreter/SwitchConstantExpressionsInterpreter.xtend
@@ -63,17 +63,17 @@ class SwitchConstantExpressionsInterpreter extends AbstractConstantExpressionsIn
 						// to evaluate non-static final fields when checking for duplicate cases.
 						&& (feature.static || ctx instanceof SwitchContext && (ctx as SwitchContext).validationMode)) {
 					val associatedExpression = feature.associatedExpression
-					if (associatedExpression != null) {
+					if (associatedExpression !== null) {
 						return associatedExpression.evaluateAssociatedExpression(ctx)
 					}
 				}
 			}
-			XVariableDeclaration case !feature.writeable && feature.right != null: {
+			XVariableDeclaration case !feature.writeable && feature.right !== null: {
 				return feature.right.evaluateAssociatedExpression(ctx)
 			}
 			JvmFormalParameter: {
 				switch container : feature.eContainer {
-					XSwitchExpression case container.^switch != null: {
+					XSwitchExpression case container.^switch !== null: {
 						return container.^switch.evaluate(ctx)
 					}
 				}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/jvmmodel/JvmTypeExtensions.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/jvmmodel/JvmTypeExtensions.xtend
@@ -42,9 +42,9 @@ class JvmTypeExtensions {
 	
 	def isSingleSyntheticDefaultConstructor(JvmConstructor it) {
 		return parameters.empty && 
-			associatedExpression == null && 
-			compilationStrategy == null && 
-			compilationTemplate == null &&
+			associatedExpression === null && 
+			compilationStrategy === null && 
+			compilationTemplate === null &&
 			declaringType.members.filter(JvmConstructor).size == 1
 	}
 	
@@ -75,7 +75,7 @@ class JvmTypeExtensions {
 	 */
 	def protected JvmIdentifiableMetaData getMetaData(EObject element) {
 		var metaData = EcoreUtil.getAdapter(element.eAdapters, JvmIdentifiableMetaData) as JvmIdentifiableMetaData
-		if (metaData == null) {
+		if (metaData === null) {
 			metaData = new JvmIdentifiableMetaData
 			element.eAdapters += metaData
 		}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageFacade.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageFacade.xtend
@@ -35,7 +35,7 @@ class BatchLinkableResourceStorageFacade extends ResourceStorageFacade {
 		if (mainProject !== null) {
 			val project = mainProject.workspaceConfig.findProjectContaining(uri)
 			val sourceFolder = project?.findSourceFolderContaining(uri)
-			if (sourceFolder != null) {
+			if (sourceFolder !== null) {
 				return sourceFolder.path
 			}
 		}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageWritable.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageWritable.xtend
@@ -79,7 +79,7 @@ import java.io.IOException
 			out.writeBoolean(false)
 		}
 		// store additional meta data
-		if (metaDataAdapter != null) {
+		if (metaDataAdapter !== null) {
 			out.writeBoolean(true)
 			out.writeBoolean(metaDataAdapter.synthetic)
 		} else {
@@ -135,7 +135,7 @@ import java.io.IOException
 	}
 
 	protected def String getFragment(EObject obj) {
-		if (obj==null || obj.eIsProxy || obj.eResource == null) {
+		if (obj==null || obj.eIsProxy || obj.eResource === null) {
 			return "none"
 		}
 		obj.eResource.getURIFragment(obj)

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/JvmElementAtOffsetHelper.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/JvmElementAtOffsetHelper.xtend
@@ -26,7 +26,7 @@ class JvmElementAtOffsetHelper {
 
 	def JvmIdentifiableElement getJvmIdentifiableElement(XtextResource resource, int offset) {
 		val selectedElement = eObjectAtOffsetHelper.resolveElementAt(resource, offset)
-		if(selectedElement == null)
+		if(selectedElement === null)
 			return null
 		if(selectedElement instanceof JvmIdentifiableElement)
 			return selectedElement

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/references/DataTypes.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/references/DataTypes.xtend
@@ -42,7 +42,7 @@ class LightweightBoundTypeArgument {
 	VarianceInfo actualVariance
 	
 	def isValidVariancePair() {
-		declaredVariance.mergeDeclaredWithActual(actualVariance) != null
+		declaredVariance.mergeDeclaredWithActual(actualVariance) !== null
 	}
 }
 

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/references/IndexingLightweightTypeReferenceFactory.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/references/IndexingLightweightTypeReferenceFactory.xtend
@@ -43,7 +43,7 @@ class IndexingLightweightTypeReferenceFactory extends LightweightTypeReferenceFa
 
 	def dispatch JvmType getType(JvmGenericArrayTypeReferenceImplCustom it) {
 		val componentTypeReference = componentType
-		if (componentTypeReference == null) {
+		if (componentTypeReference === null) {
 			return null
 		}
 		switch componentType : getType(componentTypeReference) {
@@ -67,10 +67,10 @@ class IndexingLightweightTypeReferenceFactory extends LightweightTypeReferenceFa
 
 	def isProcedure(XFunctionTypeRefImplCustom it) {
 		val returnType = returnType
-		if (returnType == null)
+		if (returnType === null)
 			return true;
 		val type = getType(returnType);
-		if (type == null)
+		if (type === null)
 			return false;
 		if (type.eIsProxy)
 			return false;
@@ -102,7 +102,7 @@ class IndexingLightweightTypeReferenceFactory extends LightweightTypeReferenceFa
 			typeArgument.addUpperBound(javaLangObjectTypeReference)
 			result.addTypeArgument(typeArgument);
 		}
-		if (reference.getReturnType() != null) {
+		if (reference.getReturnType() !== null) {
 			val returnType = visit(wrapIfNecessary(reference.getReturnType()))
 			result.setReturnType(returnType);
 			if (reference instanceof XFunctionTypeRefImplCustom) {
@@ -118,7 +118,7 @@ class IndexingLightweightTypeReferenceFactory extends LightweightTypeReferenceFa
 	}
 
 	def JvmTypeReference wrapIfNecessary(JvmTypeReference reference) {
-		if (reference == null) {
+		if (reference === null) {
 			return null
 		}
 		val type = getType(reference)

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/references/LightweightTypeReferenceSerializer.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/references/LightweightTypeReferenceSerializer.xtend
@@ -31,7 +31,7 @@ class LightweightTypeReferenceSerializer extends TypeReferenceVisitor {
 			appender.append('(')
 			appendCommaSeparated(reference.parameterTypes)
 			appender.append(')=>')
-			if(reference.returnType == null)
+			if(reference.returnType === null)
 				appender.append('void')
 			else
 				reference.returnType.accept(this)
@@ -52,7 +52,7 @@ class LightweightTypeReferenceSerializer extends TypeReferenceVisitor {
 			appender.append('(')
 			appendCommaSeparated(reference.parameterTypes)
 			appender.append(')=>')
-			if(reference.returnType == null)
+			if(reference.returnType === null)
 				appender.append('void')
 			else
 				reference.returnType.accept(this)
@@ -93,7 +93,7 @@ class LightweightTypeReferenceSerializer extends TypeReferenceVisitor {
 	
 	override protected doVisitWildcardTypeReference(/* @NonNull */ WildcardTypeReference reference) {
 		appender.append('?')
-		if(reference.lowerBound != null) {
+		if(reference.lowerBound !== null) {
 			appender.append(" super ")
 			reference.lowerBound.accept(this)
 		} else {

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/DataTypes.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/DataTypes.xtend
@@ -105,7 +105,7 @@ class ConstraintVisitingInfo {
 		visiting.remove(parameter);
 	}
 	def void pushInfo(JvmTypeParameterDeclarator declarator, int idx) {
-		if (declarator == null)
+		if (declarator === null)
 			throw new NullPointerException("declarator may not be null")
 		this.declarator = declarator;
 		this.idx = idx;

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/util/XSwitchExpressions.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/util/XSwitchExpressions.xtend
@@ -31,7 +31,7 @@ class XSwitchExpressions {
 	 */
 	def isJavaSwitchExpression(XSwitchExpression it) {
 		val switchType = switchVariableType
-		if (switchType == null) {
+		if (switchType === null) {
 			return false
 		}
 		if (switchType.isSubtypeOf(Integer.TYPE)) {
@@ -48,7 +48,7 @@ class XSwitchExpressions {
 	 */
 	def isJava7SwitchExpression(XSwitchExpression it) {
 		val switchType = switchVariableType
-		if (switchType == null) {
+		if (switchType === null) {
 			return false
 		}
 		if (switchType.isSubtypeOf(Integer.TYPE)) {
@@ -64,16 +64,16 @@ class XSwitchExpressions {
 	}
 
 	def isJavaCaseExpression(XSwitchExpression it, XCasePart casePart) {
-		if (casePart.typeGuard != null) {
+		if (casePart.typeGuard !== null) {
 			return false
 		}
 		val ^case = casePart.^case
-		if (^case == null) {
+		if (^case === null) {
 			return false
 		}
 		extension val resolvedTypes = resolveTypes
 		val caseType = ^case.actualType
-		if (caseType == null) {
+		if (caseType === null) {
 			return false
 		}
 		val switchType = switchVariableType
@@ -86,7 +86,7 @@ class XSwitchExpressions {
 	def getSwitchVariableType(XSwitchExpression it) {
 		extension val resolvedTypes = resolveTypes
 		val declaredParam = declaredParam
-		if (declaredParam == null) {
+		if (declaredParam === null) {
 			return ^switch.actualType
 		}
 		val paramType = declaredParam.actualType
@@ -95,7 +95,7 @@ class XSwitchExpressions {
 	
 	def isConstant(XCasePart casePart) {
 		val ^case = casePart.^case
-		if (^case == null) {
+		if (^case === null) {
 			return false
 		}
 		try {
@@ -108,7 +108,7 @@ class XSwitchExpressions {
 	
 	def XExpression getThen(XCasePart casePart, XSwitchExpression switchExpression) {
 		val then = casePart.then
-		if (then != null) {
+		if (then !== null) {
 			return then
 		}
 		val casePartIndex = switchExpression.cases.indexOf(casePart)

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/ConstantExpressionValidator.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/ConstantExpressionValidator.xtend
@@ -74,13 +74,13 @@ class ConstantExpressionValidator {
 			}
 			JvmOperation : {
 				val annotationReference = expression.findInlineAnnotation
-				if (annotationReference == null) {
+				if (annotationReference === null) {
 					return false
 				}
 				if (annotationReference.values.filter(JvmBooleanAnnotationValue).exists [
 					valueName=='constantExpression' && values.head.booleanValue
 				]) {
-					val receiverConstant = if (expression.actualReceiver == null) {
+					val receiverConstant = if (expression.actualReceiver === null) {
 						true
 					} else {
 						expression.actualReceiver.isConstant

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/UniqueClassNameValidator.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/UniqueClassNameValidator.xtend
@@ -47,7 +47,7 @@ class UniqueClassNameValidator extends AbstractDeclarativeValidator {
 	
 	@Check
 	def void checkUniqueName(EObject root) {
-		if (root.eContainer == null) {
+		if (root.eContainer === null) {
 			val resource = root.eResource
 			if (resource.contents.head == root) {
 				resource.contents.filter(JvmDeclaredType).forEach[ doCheckUniqueName ]
@@ -56,9 +56,9 @@ class UniqueClassNameValidator extends AbstractDeclarativeValidator {
 	}
 	
 	protected def void doCheckUniqueName(JvmDeclaredType type) {
-		if (type.eContainer == null) { // only check top-level types
+		if (type.eContainer === null) { // only check top-level types
 			val name = qualifiedNameProvider.getFullyQualifiedName(type)
-			if (name != null) {
+			if (name !== null) {
 				doCheckUniqueName(name, type)
 			}
 		}
@@ -81,7 +81,7 @@ class UniqueClassNameValidator extends AbstractDeclarativeValidator {
 	
 	protected def void addIssue(JvmDeclaredType type, String fileName) {
 		val sourceElement = associations.getPrimarySourceElement(type)
-		if (sourceElement == null)
+		if (sourceElement === null)
 			addIssue('''The type «type.simpleName» is already defined in «fileName».''', type, IssueCodes.DUPLICATE_TYPE)
 		else {
 			val feature = sourceElement.eClass.getEStructuralFeature('name')

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xtype/util/XFunctionTypeRefs.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xtype/util/XFunctionTypeRefs.xtend
@@ -46,7 +46,7 @@ class XFunctionTypeRefs {
 		switch type {
 			JvmPrimitiveType: {
 				val wrappedType = type.wrappedType
-				if (wrappedType == null) {
+				if (wrappedType === null) {
 					reference
 				} else {
 					TypesFactory.eINSTANCE.createJvmParameterizedTypeReference => [

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/annotations/formatting2/XbaseWithAnnotationsFormatter.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/annotations/formatting2/XbaseWithAnnotationsFormatter.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.annotations.formatting2;
 
-import com.google.common.base.Objects;
 import java.util.Arrays;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
@@ -75,8 +74,8 @@ public class XbaseWithAnnotationsFormatter extends XbaseFormatter {
     };
     document.surround(_keyword_1, _function_1);
     XExpression _value = ann.getValue();
-    boolean _notEquals = (!Objects.equal(_value, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_value != null);
+    if (_tripleNotEquals) {
       XExpression _value_1 = ann.getValue();
       document.<XExpression>format(_value_1);
       ISemanticRegionsFinder _regionFor_2 = this.textRegionExtensions.regionFor(ann);

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/annotations/validation/UnresolvedFeatureCallTypeAwareMessageProvider.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/annotations/validation/UnresolvedFeatureCallTypeAwareMessageProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.annotations.validation;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.List;
 import org.eclipse.emf.ecore.EClass;
@@ -154,8 +153,7 @@ public class UnresolvedFeatureCallTypeAwareMessageProvider extends LinkingDiagno
     }
     _builder.append(" is undefined");
     String msg = _builder.toString();
-    boolean _notEquals = (!Objects.equal(recieverType, null));
-    if (_notEquals) {
+    if ((recieverType != null)) {
       String _msg = msg;
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append(" ");

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/DisableCodeGenerationAdapter.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/DisableCodeGenerationAdapter.java
@@ -24,13 +24,13 @@ public class DisableCodeGenerationAdapter extends AdapterImpl {
   
   public static boolean isDisabled(final JvmDeclaredType type) {
     Adapter _adapter = DisableCodeGenerationAdapter.getAdapter(type);
-    return (!Objects.equal(_adapter, null));
+    return (_adapter != null);
   }
   
   public static void disableCodeGeneration(final JvmDeclaredType declaredType) {
     Adapter _adapter = DisableCodeGenerationAdapter.getAdapter(declaredType);
-    boolean _equals = Objects.equal(_adapter, null);
-    if (_equals) {
+    boolean _tripleEquals = (_adapter == null);
+    if (_tripleEquals) {
       EList<Adapter> _eAdapters = declaredType.eAdapters();
       DisableCodeGenerationAdapter _disableCodeGenerationAdapter = new DisableCodeGenerationAdapter();
       _eAdapters.add(_disableCodeGenerationAdapter);
@@ -39,8 +39,7 @@ public class DisableCodeGenerationAdapter extends AdapterImpl {
   
   public static void enableCodeGeneration(final JvmDeclaredType declaredType) {
     final Adapter adapter = DisableCodeGenerationAdapter.getAdapter(declaredType);
-    boolean _notEquals = (!Objects.equal(adapter, null));
-    if (_notEquals) {
+    if ((adapter != null)) {
       EList<Adapter> _eAdapters = declaredType.eAdapters();
       _eAdapters.remove(adapter);
     }

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/ErrorSafeExtensions.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/ErrorSafeExtensions.java
@@ -167,7 +167,7 @@ public class ErrorSafeExtensions {
   }
   
   public void serializeSafely(final JvmTypeReference typeRef, final String surrogateType, final ITreeAppendable appendable) {
-    if ((Objects.equal(typeRef, null) || Objects.equal(typeRef.getType(), null))) {
+    if (((typeRef == null) || (typeRef.getType() == null))) {
       boolean _matched = false;
       if (typeRef instanceof JvmSpecializedTypeReference) {
         _matched=true;
@@ -205,8 +205,7 @@ public class ErrorSafeExtensions {
           }
         }
         this.closeErrorAppendable(appendable, errorChild);
-        boolean _notEquals = (!Objects.equal(surrogateType, null));
-        if (_notEquals) {
+        if ((surrogateType != null)) {
           appendable.append(surrogateType);
         }
       } else {
@@ -217,7 +216,7 @@ public class ErrorSafeExtensions {
   }
   
   public void serializeSafely(final JvmAnnotationReference annotationRef, final ITreeAppendable appendable, final Procedure1<? super ITreeAppendable> onSuccess) {
-    if ((Objects.equal(annotationRef, null) || Objects.equal(annotationRef.getAnnotation(), null))) {
+    if (((annotationRef == null) || (annotationRef.getAnnotation() == null))) {
       final ITreeAppendable errorChild = this.openErrorAppendable(appendable, appendable);
       errorChild.append("annotation is \'null\'");
       this.closeErrorAppendable(appendable, errorChild);

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.java
@@ -209,8 +209,8 @@ public class JvmModelGenerator implements IGenerator {
       return;
     }
     String _qualifiedName = type.getQualifiedName();
-    boolean _notEquals = (!Objects.equal(_qualifiedName, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_qualifiedName != null);
+    if (_tripleNotEquals) {
       String _qualifiedName_1 = type.getQualifiedName();
       String _replace = _qualifiedName_1.replace(".", "/");
       String _plus = (_replace + ".java");
@@ -234,8 +234,8 @@ public class JvmModelGenerator implements IGenerator {
     final TreeAppendable importAppendable = this.createAppendable(type, importManager, config);
     this.generateFileHeader(type, importAppendable, config);
     String _packageName = type.getPackageName();
-    boolean _notEquals = (!Objects.equal(_packageName, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_packageName != null);
+    if (_tripleNotEquals) {
       ITreeAppendable _append = importAppendable.append("package ");
       String _packageName_1 = type.getPackageName();
       ITreeAppendable _append_1 = _append.append(_packageName_1);
@@ -343,8 +343,8 @@ public class JvmModelGenerator implements IGenerator {
       this.generateAnnotations(_filter, appendable, true, config);
       ITreeAppendable _xifexpression = null;
       EObject _eContainer = it.eContainer();
-      boolean _equals = Objects.equal(_eContainer, null);
-      if (_equals) {
+      boolean _tripleEquals = (_eContainer == null);
+      if (_tripleEquals) {
         StringConcatenation _builder = new StringConcatenation();
         _builder.append("@SuppressWarnings(\"all\")");
         ITreeAppendable _append = appendable.append(_builder);
@@ -493,8 +493,8 @@ public class JvmModelGenerator implements IGenerator {
   
   public void generateDefaultExpression(final JvmOperation it, final ITreeAppendable appendable, final GeneratorConfig config) {
     Procedure1<? super ITreeAppendable> _compilationStrategy = this._jvmTypeExtensions.getCompilationStrategy(it);
-    boolean _notEquals = (!Objects.equal(_compilationStrategy, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_compilationStrategy != null);
+    if (_tripleNotEquals) {
       appendable.append(" default ");
       appendable.increaseIndentation();
       Procedure1<? super ITreeAppendable> _compilationStrategy_1 = this._jvmTypeExtensions.getCompilationStrategy(it);
@@ -502,8 +502,8 @@ public class JvmModelGenerator implements IGenerator {
       appendable.decreaseIndentation();
     } else {
       StringConcatenationClient _compilationTemplate = this._jvmTypeExtensions.getCompilationTemplate(it);
-      boolean _notEquals_1 = (!Objects.equal(_compilationTemplate, null));
-      if (_notEquals_1) {
+      boolean _tripleNotEquals_1 = (_compilationTemplate != null);
+      if (_tripleNotEquals_1) {
         ITreeAppendable _append = appendable.append(" default ");
         _append.increaseIndentation();
         this.appendCompilationTemplate(appendable, it);
@@ -512,8 +512,7 @@ public class JvmModelGenerator implements IGenerator {
         boolean _isGenerateExpressions = config.isGenerateExpressions();
         if (_isGenerateExpressions) {
           final XExpression body = this._iLogicalContainerProvider.getAssociatedExpression(it);
-          boolean _notEquals_2 = (!Objects.equal(body, null));
-          if (_notEquals_2) {
+          if ((body != null)) {
             boolean _hasErrors = this._errorSafeExtensions.hasErrors(body);
             if (_hasErrors) {
               appendable.append("/* skipped default expression with errors */");
@@ -524,8 +523,8 @@ public class JvmModelGenerator implements IGenerator {
             }
           } else {
             JvmAnnotationValue _defaultValue = it.getDefaultValue();
-            boolean _notEquals_3 = (!Objects.equal(_defaultValue, null));
-            if (_notEquals_3) {
+            boolean _tripleNotEquals_2 = (_defaultValue != null);
+            if (_tripleNotEquals_2) {
               JvmAnnotationValue _defaultValue_1 = it.getDefaultValue();
               boolean _hasErrors_1 = this._errorSafeExtensions.hasErrors(_defaultValue_1);
               if (_hasErrors_1) {
@@ -676,8 +675,7 @@ public class JvmModelGenerator implements IGenerator {
    * Returns the visibility modifier and a space as suffix if not empty
    */
   public String javaName(final JvmVisibility visibility) {
-    boolean _notEquals = (!Objects.equal(visibility, null));
-    if (_notEquals) {
+    if ((visibility != null)) {
       String _switchResult = null;
       if (visibility != null) {
         switch (visibility) {
@@ -757,8 +755,7 @@ public class JvmModelGenerator implements IGenerator {
         return Boolean.valueOf((!Objects.equal(typeRef, superClazz)));
       };
       final Iterable<JvmTypeReference> superInterfaces = IterableExtensions.<JvmTypeReference>filter(withoutObject_1, _function_5);
-      boolean _notEquals = (!Objects.equal(superClazz, null));
-      if (_notEquals) {
+      if ((superClazz != null)) {
         final boolean hasErrors = this._errorSafeExtensions.hasErrors(superClazz);
         if (hasErrors) {
           appendable.append("/* ");
@@ -854,8 +851,8 @@ public class JvmModelGenerator implements IGenerator {
       this.generateModifier(it, tracedAppendable, config);
       this.generateTypeParameterDeclaration(it, tracedAppendable, config);
       JvmTypeReference _returnType = it.getReturnType();
-      boolean _equals = Objects.equal(_returnType, null);
-      if (_equals) {
+      boolean _tripleEquals = (_returnType == null);
+      if (_tripleEquals) {
         tracedAppendable.append("void");
       } else {
         JvmTypeReference _returnType_1 = it.getReturnType();
@@ -911,8 +908,8 @@ public class JvmModelGenerator implements IGenerator {
   
   public void generateInitialization(final JvmField it, final ITreeAppendable appendable, final GeneratorConfig config) {
     Procedure1<? super ITreeAppendable> _compilationStrategy = this._jvmTypeExtensions.getCompilationStrategy(it);
-    boolean _notEquals = (!Objects.equal(_compilationStrategy, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_compilationStrategy != null);
+    if (_tripleNotEquals) {
       final Iterable<Issue> errors = this.getDirectErrorsOrLogicallyContainedErrors(it);
       boolean _isEmpty = IterableExtensions.isEmpty(errors);
       if (_isEmpty) {
@@ -926,8 +923,8 @@ public class JvmModelGenerator implements IGenerator {
       }
     } else {
       StringConcatenationClient _compilationTemplate = this._jvmTypeExtensions.getCompilationTemplate(it);
-      boolean _notEquals_1 = (!Objects.equal(_compilationTemplate, null));
-      if (_notEquals_1) {
+      boolean _tripleNotEquals_1 = (_compilationTemplate != null);
+      if (_tripleNotEquals_1) {
         final Iterable<Issue> errors_1 = this.getDirectErrorsOrLogicallyContainedErrors(it);
         boolean _isEmpty_1 = IterableExtensions.isEmpty(errors_1);
         if (_isEmpty_1) {
@@ -940,7 +937,7 @@ public class JvmModelGenerator implements IGenerator {
         }
       } else {
         final XExpression expression = this._iLogicalContainerProvider.getAssociatedExpression(it);
-        if (((!Objects.equal(expression, null)) && config.isGenerateExpressions())) {
+        if (((expression != null) && config.isGenerateExpressions())) {
           boolean _hasErrors = this._errorSafeExtensions.hasErrors(expression);
           if (_hasErrors) {
             appendable.append(" /* Skipped initializer because of errors */");
@@ -1069,7 +1066,7 @@ public class JvmModelGenerator implements IGenerator {
   }
   
   public boolean hasBody(final JvmExecutable it) {
-    return (((!Objects.equal(this._jvmTypeExtensions.getCompilationTemplate(it), null)) || (!Objects.equal(this._jvmTypeExtensions.getCompilationStrategy(it), null))) || (!Objects.equal(this._iLogicalContainerProvider.getAssociatedExpression(it), null)));
+    return (((this._jvmTypeExtensions.getCompilationTemplate(it) != null) || (this._jvmTypeExtensions.getCompilationStrategy(it) != null)) || (this._iLogicalContainerProvider.getAssociatedExpression(it) != null));
   }
   
   /**
@@ -1082,8 +1079,7 @@ public class JvmModelGenerator implements IGenerator {
     boolean _isEmpty = IterableExtensions.isEmpty(errors);
     if (_isEmpty) {
       final XExpression expression = this._iLogicalContainerProvider.getAssociatedExpression(feature);
-      boolean _notEquals = (!Objects.equal(expression, null));
-      if (_notEquals) {
+      if ((expression != null)) {
         Iterable<Issue> _errors = this._errorSafeExtensions.getErrors(expression);
         errors = _errors;
       }
@@ -1093,8 +1089,8 @@ public class JvmModelGenerator implements IGenerator {
   
   public void generateExecutableBody(final JvmExecutable op, final ITreeAppendable appendable, final GeneratorConfig config) {
     Procedure1<? super ITreeAppendable> _compilationStrategy = this._jvmTypeExtensions.getCompilationStrategy(op);
-    boolean _notEquals = (!Objects.equal(_compilationStrategy, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_compilationStrategy != null);
+    if (_tripleNotEquals) {
       Iterable<Issue> errors = this.getDirectErrorsOrLogicallyContainedErrors(op);
       boolean _isEmpty = IterableExtensions.isEmpty(errors);
       if (_isEmpty) {
@@ -1111,8 +1107,8 @@ public class JvmModelGenerator implements IGenerator {
       }
     } else {
       StringConcatenationClient _compilationTemplate = this._jvmTypeExtensions.getCompilationTemplate(op);
-      boolean _notEquals_1 = (!Objects.equal(_compilationTemplate, null));
-      if (_notEquals_1) {
+      boolean _tripleNotEquals_1 = (_compilationTemplate != null);
+      if (_tripleNotEquals_1) {
         final Iterable<Issue> errors_1 = this.getDirectErrorsOrLogicallyContainedErrors(op);
         boolean _isEmpty_1 = IterableExtensions.isEmpty(errors_1);
         if (_isEmpty_1) {
@@ -1128,7 +1124,7 @@ public class JvmModelGenerator implements IGenerator {
         }
       } else {
         final XExpression expression = this._iLogicalContainerProvider.getAssociatedExpression(op);
-        if (((!Objects.equal(expression, null)) && config.isGenerateExpressions())) {
+        if (((expression != null) && config.isGenerateExpressions())) {
           final Iterable<Issue> errors_2 = this._errorSafeExtensions.getErrors(expression);
           boolean _isEmpty_2 = IterableExtensions.isEmpty(errors_2);
           if (_isEmpty_2) {
@@ -1240,8 +1236,7 @@ public class JvmModelGenerator implements IGenerator {
         }
       }
       String _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(superType, null));
-      if (_notEquals) {
+      if ((superType != null)) {
         _xifexpression = b.declareVariable(superType, "super");
       }
       _xblockexpression = _xifexpression;
@@ -1267,8 +1262,7 @@ public class JvmModelGenerator implements IGenerator {
         }
       }
       String _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(declaredType, null));
-      if (_notEquals) {
+      if ((declaredType != null)) {
         _xifexpression = b.declareVariable(declaredType, "this");
       }
       _xblockexpression = _xifexpression;
@@ -1360,14 +1354,13 @@ public class JvmModelGenerator implements IGenerator {
       for (final ReplaceRegion region : _computeTypeRefRegions) {
         {
           final String text = region.getText();
-          if (((!Objects.equal(text, null)) && (text.length() > 0))) {
+          if (((text != null) && (text.length() > 0))) {
             final QualifiedName fqn = this.qualifiedNameConverter.toQualifiedName(text);
             final EObject context = NodeModelUtils.findActualSemanticObjectFor(node);
-            if (((fqn.getSegmentCount() == 1) && (!Objects.equal(context, null)))) {
+            if (((fqn.getSegmentCount() == 1) && (context != null))) {
               final IScope scope = this.scopeProvider.getScope(context, TypesPackage.Literals.JVM_PARAMETERIZED_TYPE_REFERENCE__TYPE);
               final IEObjectDescription candidate = scope.getSingleElement(fqn);
-              boolean _notEquals = (!Objects.equal(candidate, null));
-              if (_notEquals) {
+              if ((candidate != null)) {
                 EObject _xifexpression = null;
                 EObject _eObjectOrProxy = candidate.getEObjectOrProxy();
                 boolean _eIsProxy = _eObjectOrProxy.eIsProxy();
@@ -1383,8 +1376,8 @@ public class JvmModelGenerator implements IGenerator {
                   final JvmDeclaredType contextDeclarator = EcoreUtil2.<JvmDeclaredType>getContainerOfType(it, JvmDeclaredType.class);
                   String _packageName = referencedType.getPackageName();
                   String _packageName_1 = contextDeclarator.getPackageName();
-                  boolean _notEquals_1 = (!Objects.equal(_packageName, _packageName_1));
-                  if (_notEquals_1) {
+                  boolean _notEquals = (!Objects.equal(_packageName, _packageName_1));
+                  if (_notEquals) {
                     final ImportManager importManager = this.getImportManager(appendable);
                     importManager.addImportFor(jvmType);
                   }
@@ -1496,12 +1489,12 @@ public class JvmModelGenerator implements IGenerator {
   
   public void toJava(final JvmAnnotationValue it, final ITreeAppendable appendable, final GeneratorConfig config) {
     JvmOperation _operation = it.getOperation();
-    boolean _notEquals = (!Objects.equal(_operation, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_operation != null);
+    if (_tripleNotEquals) {
       JvmOperation _operation_1 = it.getOperation();
       String _simpleName = _operation_1.getSimpleName();
-      boolean _equals = Objects.equal(_simpleName, null);
-      if (_equals) {
+      boolean _tripleEquals = (_simpleName == null);
+      if (_tripleEquals) {
         return;
       }
       JvmOperation _operation_2 = it.getOperation();
@@ -1742,8 +1735,7 @@ public class JvmModelGenerator implements IGenerator {
   
   public JvmGenericType containerType(final EObject context) {
     JvmGenericType _xifexpression = null;
-    boolean _equals = Objects.equal(context, null);
-    if (_equals) {
+    if ((context == null)) {
       _xifexpression = null;
     } else {
       JvmGenericType _xifexpression_1 = null;
@@ -1760,8 +1752,7 @@ public class JvmModelGenerator implements IGenerator {
   
   protected String makeJavaIdentifier(final String name) {
     String _xifexpression = null;
-    boolean _equals = Objects.equal(name, null);
-    if (_equals) {
+    if ((name == null)) {
       return "__unknown__";
     } else {
       String _xifexpression_1 = null;

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/TreeAppendableUtil.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/TreeAppendableUtil.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.compiler;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.generator.trace.LocationData;
@@ -73,7 +72,7 @@ public class TreeAppendableUtil {
         }
         final ITextRegionWithLineInformation it = ((ITextRegionWithLineInformation) _switchResult);
         ITreeAppendable _xifexpression_1 = null;
-        if (((!Objects.equal(it, null)) && (it != ITextRegion.EMPTY_REGION))) {
+        if (((it != null) && (it != ITextRegion.EMPTY_REGION))) {
           int _offset = it.getOffset();
           int _length = it.getLength();
           int _lineNumber = it.getLineNumber();

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/controlflow/ConstantConditionsInterpreter.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/controlflow/ConstantConditionsInterpreter.java
@@ -143,7 +143,7 @@ public class ConstantConditionsInterpreter {
   
   protected EvaluationResult _internalEvaluate(final XAbstractFeatureCall it, final EvaluationContext context) {
     final JvmIdentifiableElement feature = this.getFeature(it, context);
-    if ((Objects.equal(feature, null) || feature.eIsProxy())) {
+    if (((feature == null) || feature.eIsProxy())) {
       return EvaluationResult.NOT_A_CONSTANT;
     }
     boolean _matched = false;
@@ -183,8 +183,8 @@ public class ConstantConditionsInterpreter {
           boolean _isFinal = ((JvmField)feature).isFinal();
           if (_isFinal) {
             XExpression _actualReceiver = it.getActualReceiver();
-            boolean _notEquals = (!Objects.equal(_actualReceiver, null));
-            if (_notEquals) {
+            boolean _tripleNotEquals = (_actualReceiver != null);
+            if (_tripleNotEquals) {
               XExpression _actualReceiver_1 = it.getActualReceiver();
               final EvaluationResult receiver = this.doEvaluate(_actualReceiver_1, context);
               boolean _isNotAConstant = receiver.isNotAConstant();
@@ -192,8 +192,7 @@ public class ConstantConditionsInterpreter {
                 return receiver;
               }
               final XExpression associatedExpression = this.getAssociatedExpression(((JvmField)feature));
-              boolean _notEquals_1 = (!Objects.equal(associatedExpression, null));
-              if (_notEquals_1) {
+              if ((associatedExpression != null)) {
                 final EvaluationResult result = this.evaluateAssociatedExpression(associatedExpression, context);
                 Object _rawValue = result.getRawValue();
                 if ((_rawValue instanceof ThisReference)) {
@@ -229,8 +228,7 @@ public class ConstantConditionsInterpreter {
               }
             } else {
               final XExpression associatedExpression_1 = this.getAssociatedExpression(((JvmField)feature));
-              boolean _notEquals_2 = (!Objects.equal(associatedExpression_1, null));
-              if (_notEquals_2) {
+              if ((associatedExpression_1 != null)) {
                 final EvaluationResult result_1 = this.evaluateAssociatedExpression(associatedExpression_1, context);
                 Object _rawValue_3 = result_1.getRawValue();
                 return new EvaluationResult(_rawValue_3, false);
@@ -245,7 +243,7 @@ public class ConstantConditionsInterpreter {
     }
     if (!_matched) {
       if (feature instanceof XVariableDeclaration) {
-        if (((!((XVariableDeclaration)feature).isWriteable()) && (!Objects.equal(((XVariableDeclaration)feature).getRight(), null)))) {
+        if (((!((XVariableDeclaration)feature).isWriteable()) && (((XVariableDeclaration)feature).getRight() != null))) {
           _matched=true;
           XExpression _right = ((XVariableDeclaration)feature).getRight();
           return this.evaluateAssociatedExpression(_right, context);
@@ -260,8 +258,8 @@ public class ConstantConditionsInterpreter {
         boolean _matched_1 = false;
         if (container instanceof XSwitchExpression) {
           XExpression _switch = ((XSwitchExpression)container).getSwitch();
-          boolean _notEquals = (!Objects.equal(_switch, null));
-          if (_notEquals) {
+          boolean _tripleNotEquals = (_switch != null);
+          if (_tripleNotEquals) {
             _matched_1=true;
             XExpression _switch_1 = ((XSwitchExpression)container).getSwitch();
             return this.doEvaluate(_switch_1, context);
@@ -276,7 +274,7 @@ public class ConstantConditionsInterpreter {
   public JvmIdentifiableElement getFeature(final XAbstractFeatureCall call, final EvaluationContext context) {
     Object _eGet = call.eGet(XbasePackage.Literals.XABSTRACT_FEATURE_CALL__FEATURE, false);
     JvmIdentifiableElement feature = ((JvmIdentifiableElement) _eGet);
-    if ((Objects.equal(feature, null) || feature.eIsProxy())) {
+    if (((feature == null) || feature.eIsProxy())) {
       IResolvedTypes _resolvedTypes = context.getResolvedTypes();
       JvmIdentifiableElement _linkedFeature = _resolvedTypes.getLinkedFeature(call);
       feature = _linkedFeature;
@@ -399,7 +397,7 @@ public class ConstantConditionsInterpreter {
   }
   
   protected EvaluationResult _internalEvaluate(final XBinaryOperation it, final EvaluationContext context) {
-    if ((this.isFromXbaseLibrary(it, context) && (!Objects.equal(it.getRightOperand(), null)))) {
+    if ((this.isFromXbaseLibrary(it, context) && (it.getRightOperand() != null))) {
       XExpression _leftOperand = it.getLeftOperand();
       final EvaluationResult left = this.doEvaluate(_leftOperand, context);
       XExpression _rightOperand = it.getRightOperand();

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/controlflow/DefaultEarlyExitComputer.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/controlflow/DefaultEarlyExitComputer.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.controlflow;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -55,13 +54,12 @@ public class DefaultEarlyExitComputer implements IEarlyExitComputer {
   }
   
   protected boolean isNotEmpty(final Collection<IEarlyExitComputer.ExitPoint> exitPoints) {
-    return ((!Objects.equal(exitPoints, null)) && (!exitPoints.isEmpty()));
+    return ((exitPoints != null) && (!exitPoints.isEmpty()));
   }
   
   @Override
   public Collection<IEarlyExitComputer.ExitPoint> getExitPoints(final XExpression expression) {
-    boolean _equals = Objects.equal(expression, null);
-    if (_equals) {
+    if ((expression == null)) {
       return Collections.<IEarlyExitComputer.ExitPoint>emptyList();
     }
     return this.exitPoints(expression);
@@ -115,7 +113,7 @@ public class DefaultEarlyExitComputer implements IEarlyExitComputer {
     if (_isNotEmpty) {
       return exitPoints;
     }
-    if ((Objects.equal(predicate, null) || this.isBooleanConstant(predicate, true))) {
+    if (((predicate == null) || this.isBooleanConstant(predicate, true))) {
       XExpression _eachExpression = expression.getEachExpression();
       Collection<IEarlyExitComputer.ExitPoint> _exitPoints = this.getExitPoints(_eachExpression);
       exitPoints = _exitPoints;
@@ -236,8 +234,7 @@ public class DefaultEarlyExitComputer implements IEarlyExitComputer {
     for (final XCasePart casePart : _cases) {
       {
         XExpression then = casePart.getThen();
-        boolean _notEquals = (!Objects.equal(then, null));
-        if (_notEquals) {
+        if ((then != null)) {
           Collection<IEarlyExitComputer.ExitPoint> caseExit = this.getExitPoints(then);
           boolean _isNotEmpty_1 = this.isNotEmpty(caseExit);
           boolean _not = (!_isNotEmpty_1);

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/FormattableDocument.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/FormattableDocument.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.xbase.formatting;
 
-import com.google.common.base.Objects;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -65,13 +64,12 @@ public class FormattableDocument {
   }
   
   public boolean isDebugConflicts() {
-    return (!Objects.equal(this.rootTrace, null));
+    return (this.rootTrace != null);
   }
   
   protected FormattingData addFormatting(final FormattingData data) {
     FormattingData _xifexpression = null;
-    boolean _notEquals = (!Objects.equal(data, null));
-    if (_notEquals) {
+    if ((data != null)) {
       FormattingData _xblockexpression = null;
       {
         int _length = data.getLength();
@@ -128,16 +126,14 @@ public class FormattableDocument {
         int _offset_2 = data.getOffset();
         final FormattingData old = this.formattings.get(Integer.valueOf(_offset_2));
         FormattingData _xifexpression_1 = null;
-        boolean _equals = Objects.equal(old, null);
-        if (_equals) {
+        if ((old == null)) {
           _xifexpression_1 = data;
         } else {
           _xifexpression_1 = this.merge(old, data);
         }
         final FormattingData newData = _xifexpression_1;
         FormattingData _xifexpression_2 = null;
-        boolean _notEquals_1 = (!Objects.equal(newData, null));
-        if (_notEquals_1) {
+        if ((newData != null)) {
           int _offset_3 = data.getOffset();
           _xifexpression_2 = this.formattings.put(Integer.valueOf(_offset_3), newData);
         }
@@ -173,8 +169,7 @@ public class FormattableDocument {
         }
       }
       FormattingData _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(old, null));
-      if (_notEquals) {
+      if ((old != null)) {
         FormattingData _xblockexpression_1 = null;
         {
           if ((indentationChange > 0)) {
@@ -332,8 +327,7 @@ public class FormattableDocument {
   }
   
   public void operator_add(final Iterable<FormattingData> data) {
-    boolean _notEquals = (!Objects.equal(data, null));
-    if (_notEquals) {
+    if ((data != null)) {
       final Consumer<FormattingData> _function = (FormattingData it) -> {
         this.addFormatting(it);
       };
@@ -342,8 +336,7 @@ public class FormattableDocument {
   }
   
   public void operator_add(final Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> data) {
-    boolean _notEquals = (!Objects.equal(data, null));
-    if (_notEquals) {
+    if ((data != null)) {
       Iterable<FormattingData> _apply = data.apply(this);
       this.operator_add(_apply);
     }
@@ -373,8 +366,8 @@ public class FormattableDocument {
             if (f instanceof WhitespaceData) {
               _matched=true;
               String _space = ((WhitespaceData)f).getSpace();
-              boolean _notEquals = (!Objects.equal(_space, null));
-              if (_notEquals) {
+              boolean _tripleNotEquals = (_space != null);
+              if (_tripleNotEquals) {
                 final String replacement = ((WhitespaceData)f).getSpace();
                 int _offset_1 = ((WhitespaceData)f).getOffset();
                 int _length = ((WhitespaceData)f).getLength();
@@ -516,8 +509,7 @@ public class FormattableDocument {
         if ((f_2 instanceof WhitespaceData)) {
           final String space = ((WhitespaceData)f_2).getSpace();
           int _xifexpression = (int) 0;
-          boolean _equals = Objects.equal(space, null);
-          if (_equals) {
+          if ((space == null)) {
             _xifexpression = 0;
           } else {
             _xifexpression = space.length();

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/FormattingDataFactory.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/FormattingDataFactory.java
@@ -60,7 +60,7 @@ public class FormattingDataFactory {
         _elvis = Integer.valueOf(0);
       }
       final int newLines2 = (int) _elvis;
-      if (((Objects.equal(it.space, null) && Objects.equal(it.newLines, null)) || ((leafs.getNewLinesInComments() == 0) && ((newLines2 == 0) || Objects.equal(it.space, ""))))) {
+      if ((((it.space == null) && (it.newLines == null)) || ((leafs.getNewLinesInComments() == 0) && ((newLines2 == 0) || Objects.equal(it.space, ""))))) {
         boolean _isDebugConflicts = doc.isDebugConflicts();
         return this.newWhitespaceData(leafs, it.space, it.increaseIndentationChange, it.decreaseIndentationChange, _isDebugConflicts);
       } else {
@@ -412,8 +412,7 @@ public class FormattingDataFactory {
   
   public Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> append(final INode node, final Procedure1<? super FormattingDataInit> init) {
     Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _xifexpression = null;
-    boolean _notEquals = (!Objects.equal(node, null));
-    if (_notEquals) {
+    if ((node != null)) {
       HiddenLeafs _hiddenLeafsAfter = this._hiddenLeafAccess.getHiddenLeafsAfter(node);
       _xifexpression = this.newFormattingData(_hiddenLeafsAfter, init);
     }
@@ -422,8 +421,7 @@ public class FormattingDataFactory {
   
   public Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> prepend(final INode node, final Procedure1<? super FormattingDataInit> init) {
     Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _xifexpression = null;
-    boolean _notEquals = (!Objects.equal(node, null));
-    if (_notEquals) {
+    if ((node != null)) {
       HiddenLeafs _hiddenLeafsBefore = this._hiddenLeafAccess.getHiddenLeafsBefore(node);
       _xifexpression = this.newFormattingData(_hiddenLeafsBefore, init);
     }
@@ -435,8 +433,7 @@ public class FormattingDataFactory {
       ArrayList<FormattingData> _xblockexpression = null;
       {
         final ArrayList<FormattingData> result = CollectionLiterals.<FormattingData>newArrayList();
-        boolean _notEquals = (!Objects.equal(node, null));
-        if (_notEquals) {
+        if ((node != null)) {
           Iterable<FormattingData> _elvis = null;
           HiddenLeafs _hiddenLeafsBefore = this._hiddenLeafAccess.getHiddenLeafsBefore(node);
           Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _newFormattingData = this.newFormattingData(_hiddenLeafsBefore, init);
@@ -478,8 +475,7 @@ public class FormattingDataFactory {
       ArrayList<FormattingData> _xblockexpression = null;
       {
         final ArrayList<FormattingData> result = CollectionLiterals.<FormattingData>newArrayList();
-        boolean _notEquals = (!Objects.equal(node, null));
-        if (_notEquals) {
+        if ((node != null)) {
           Iterable<FormattingData> _elvis = null;
           HiddenLeafs _hiddenLeafsBefore = this._hiddenLeafAccess.getHiddenLeafsBefore(node);
           Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _newFormattingData = this.newFormattingData(_hiddenLeafsBefore, before);

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/HiddenLeafAccess.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/HiddenLeafAccess.java
@@ -42,8 +42,7 @@ public class HiddenLeafAccess {
       final ILeafNode start = this._nodeModelAccess.findNextLeaf(node, _function);
       final List<ILeafNode> nodes = this.findPreviousHiddenLeafs(start);
       HiddenLeafs _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(start, null));
-      if (_notEquals) {
+      if ((start != null)) {
         int _xifexpression_1 = (int) 0;
         boolean _isEmpty = nodes.isEmpty();
         if (_isEmpty) {
@@ -157,8 +156,7 @@ public class HiddenLeafAccess {
       };
       final ILeafNode start = this.findPreviousLeaf(node, _function);
       HiddenLeafs _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(start, null));
-      if (_notEquals) {
+      if ((start != null)) {
         int _endOffset = start.getEndOffset();
         List<ILeafNode> _findNextHiddenLeafs = this.findNextHiddenLeafs(start);
         _xifexpression = this.newHiddenLeafs(_endOffset, _findNextHiddenLeafs);
@@ -206,8 +204,7 @@ public class HiddenLeafAccess {
     if (((current instanceof ILeafNode) && (matches.apply(((ILeafNode) current))).booleanValue())) {
       return ((ILeafNode) current);
     }
-    boolean _notEquals = (!Objects.equal(current, null));
-    if (_notEquals) {
+    if ((current != null)) {
       final NodeIterator ni = new NodeIterator(current);
       while (ni.hasPrevious()) {
         {
@@ -230,8 +227,7 @@ public class HiddenLeafAccess {
         current = _lastChild;
       }
       final ArrayList<ILeafNode> result = CollectionLiterals.<ILeafNode>newArrayList();
-      boolean _notEquals = (!Objects.equal(current, null));
-      if (_notEquals) {
+      if ((current != null)) {
         final NodeIterator ni = new NodeIterator(current);
         while (ni.hasPrevious()) {
           {

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/NewLineData.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/NewLineData.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.xbase.formatting;
 
-import com.google.common.base.Objects;
 import org.eclipse.xtend.lib.annotations.Data;
 import org.eclipse.xtext.formatting2.IHiddenRegionFormatter;
 import org.eclipse.xtext.xbase.formatting.FormattingData;
@@ -18,7 +17,7 @@ public class NewLineData extends FormattingData {
   
   @Override
   public boolean isEmpty() {
-    return Objects.equal(this.newLines, null);
+    return (this.newLines == null);
   }
   
   public NewLineData(final int offset, final int length, final int increaseIndentationChange, final int decreaseIndentationChange, final Throwable trace, final Integer newLines) {

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/NodeModelAccess.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/NodeModelAccess.java
@@ -82,7 +82,7 @@ public class NodeModelAccess {
       };
       final ILeafNode result = this.findNextLeaf(current1, _function);
       ILeafNode _xifexpression = null;
-      if (((!Objects.equal(result, null)) && Objects.equal(result.getText(), kw))) {
+      if (((result != null) && Objects.equal(result.getText(), kw))) {
         _xifexpression = result;
       }
       _xblockexpression = _xifexpression;
@@ -92,8 +92,7 @@ public class NodeModelAccess {
   
   public ILeafNode findNextLeaf(final INode node, final Function1<? super ILeafNode, ? extends Boolean> matches) {
     Object _xifexpression = null;
-    boolean _notEquals = (!Objects.equal(node, null));
-    if (_notEquals) {
+    if ((node != null)) {
       if (((node instanceof ILeafNode) && (matches.apply(((ILeafNode) node))).booleanValue())) {
         return ((ILeafNode) node);
       }

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/WhitespaceData.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/WhitespaceData.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.xbase.formatting;
 
-import com.google.common.base.Objects;
 import org.eclipse.xtend.lib.annotations.Data;
 import org.eclipse.xtext.formatting2.IHiddenRegionFormatter;
 import org.eclipse.xtext.xbase.formatting.FormattingData;
@@ -18,7 +17,7 @@ public class WhitespaceData extends FormattingData {
   
   @Override
   public boolean isEmpty() {
-    return Objects.equal(this.space, null);
+    return (this.space == null);
   }
   
   public WhitespaceData(final int offset, final int length, final int increaseIndentationChange, final int decreaseIndentationChange, final Throwable trace, final String space) {

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/XbaseFormatter2.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/XbaseFormatter2.java
@@ -158,8 +158,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
               Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _append_1 = this._formattingDataFactory.append(open, _function_1);
               format.operator_add(_append_1);
             } else {
-              boolean _notEquals = (!Objects.equal(comma, null));
-              if (_notEquals) {
+              if ((comma != null)) {
                 final Procedure1<FormattingDataInit> _function_2 = (FormattingDataInit it) -> {
                   it.newLine();
                 };
@@ -197,8 +196,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
         {
           boolean _fitsIntoLine = this.fitsIntoLine(format, elem_1);
           if (_fitsIntoLine) {
-            boolean _equals = Objects.equal(comma_1, null);
-            if (_equals) {
+            if ((comma_1 == null)) {
               final Procedure1<FormattingDataInit> _function_1 = (FormattingDataInit it) -> {
                 it.noSpace();
               };
@@ -213,8 +211,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
             }
           } else {
             INode _xifexpression = null;
-            boolean _equals_1 = Objects.equal(comma_1, null);
-            if (_equals_1) {
+            if ((comma_1 == null)) {
               _xifexpression = open;
             } else {
               _xifexpression = comma_1;
@@ -297,8 +294,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
     };
     ObjectExtensions.<ILeafNode>operator_doubleArrow(_nodeForKeyword_1, _function_1);
     XExpression _value = ann.getValue();
-    boolean _notEquals = (!Objects.equal(_value, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_value != null);
+    if (_tripleNotEquals) {
       XExpression _value_1 = ann.getValue();
       this.format(_value_1, document);
       ILeafNode _nodeForKeyword_2 = this._nodeModelAccess.nodeForKeyword(ann, ")");
@@ -589,7 +586,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
   protected boolean fitsIntoLine(final FormattableDocument fmt, final EObject expression) {
     final INode node = this._nodeModelAccess.nodeForEObject(expression);
     final String lookahead = this.lookahead(fmt, expression);
-    if ((Objects.equal(node, null) || lookahead.contains("\n"))) {
+    if (((node == null) || lookahead.contains("\n"))) {
       return false;
     } else {
       int _offset = node.getOffset();
@@ -609,8 +606,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
       this.format(expression, lookahead);
       final INode node = this._nodeModelAccess.nodeForEObject(expression);
       String _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(node, null));
-      if (_notEquals) {
+      if ((node != null)) {
         String _xblockexpression_1 = null;
         {
           final ITextRegion textRegion = node.getTextRegion();
@@ -669,8 +665,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
               indented = true;
             }
           } else {
-            boolean _notEquals = (!Objects.equal(node, null));
-            if (_notEquals) {
+            if ((node != null)) {
               boolean _fitsIntoLine_1 = this.fitsIntoLine(format, arg);
               if (_fitsIntoLine_1) {
                 final Procedure1<FormattingDataInit> _function_4 = (FormattingDataInit it) -> {
@@ -726,8 +721,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
       Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _append_1 = this._formattingDataFactory.append(_nodeForEObject, _function_1);
       format.operator_add(_append_1);
     }
-    boolean _notEquals = (!Objects.equal(builder, null));
-    if (_notEquals) {
+    if ((builder != null)) {
       INode _nodeForEObject_1 = this._nodeModelAccess.nodeForEObject(builder);
       final Procedure1<FormattingDataInit> _function_2 = (FormattingDataInit it) -> {
         boolean _isMultilineLambda = this.isMultilineLambda(builder);
@@ -746,8 +740,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
   protected XClosure builder(final List<XExpression> params) {
     XClosure _xifexpression = null;
     XExpression _last = IterableExtensions.<XExpression>last(params);
-    boolean _notEquals = (!Objects.equal(_last, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_last != null);
+    if (_tripleNotEquals) {
       XClosure _xblockexpression = null;
       {
         XExpression _last_1 = IterableExtensions.<XExpression>last(params);
@@ -773,8 +767,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
     {
       final XClosure builder = this.builder(params);
       Iterable<XExpression> _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(builder, null));
-      if (_notEquals) {
+      if ((builder != null)) {
         int _size = params.size();
         int _minus = (_size - 1);
         _xifexpression = IterableExtensions.<XExpression>take(params, _minus);
@@ -811,8 +804,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
             Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _prepend = this._formattingDataFactory.prepend(head, _function_1);
             format.operator_add(_prepend);
           } else {
-            boolean _notEquals = (!Objects.equal(node, null));
-            if (_notEquals) {
+            if ((node != null)) {
               final Procedure1<FormattingDataInit> _function_2 = (FormattingDataInit it) -> {
                 it.newLine();
               };
@@ -843,8 +835,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
         }
       }
     }
-    boolean _notEquals = (!Objects.equal(builder, null));
-    if (_notEquals) {
+    if ((builder != null)) {
       INode _nodeForEObject = this._nodeModelAccess.nodeForEObject(builder);
       final Procedure1<FormattingDataInit> _function_1 = (FormattingDataInit it) -> {
         boolean _isMultilineLambda = this.isMultilineLambda(builder);
@@ -870,8 +861,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
     if (closingBracket!=null) {
       _hiddenLeafsBefore=this._hiddenLeafAccess.getHiddenLeafsBefore(closingBracket);
     }
-    boolean _notEquals = (!Objects.equal(_hiddenLeafsBefore, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_hiddenLeafsBefore != null);
+    if (_tripleNotEquals) {
       HiddenLeafs _hiddenLeafsBefore_1 = this._hiddenLeafAccess.getHiddenLeafsBefore(closingBracket);
       int _newLines = _hiddenLeafsBefore_1.getNewLines();
       return (_newLines > 0);
@@ -1029,8 +1020,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
     if (closingBracket!=null) {
       _hiddenLeafsBefore=this._hiddenLeafAccess.getHiddenLeafsBefore(closingBracket);
     }
-    boolean _notEquals = (!Objects.equal(_hiddenLeafsBefore, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_hiddenLeafsBefore != null);
+    if (_tripleNotEquals) {
       HiddenLeafs _hiddenLeafsBefore_1 = this._hiddenLeafAccess.getHiddenLeafsBefore(closingBracket);
       int _newLines = _hiddenLeafsBefore_1.getNewLines();
       return (_newLines > 0);
@@ -1046,8 +1037,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
     if (closingBracket!=null) {
       _hiddenLeafsBefore=this._hiddenLeafAccess.getHiddenLeafsBefore(closingBracket);
     }
-    boolean _notEquals = (!Objects.equal(_hiddenLeafsBefore, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_hiddenLeafsBefore != null);
+    if (_tripleNotEquals) {
       HiddenLeafs _hiddenLeafsBefore_1 = this._hiddenLeafAccess.getHiddenLeafsBefore(closingBracket);
       int _newLines = _hiddenLeafsBefore_1.getNewLines();
       return (_newLines > 0);
@@ -1063,8 +1054,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
     if (closingBracket!=null) {
       _hiddenLeafsBefore=this._hiddenLeafAccess.getHiddenLeafsBefore(closingBracket);
     }
-    boolean _notEquals = (!Objects.equal(_hiddenLeafsBefore, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_hiddenLeafsBefore != null);
+    if (_tripleNotEquals) {
       HiddenLeafs _hiddenLeafsBefore_1 = this._hiddenLeafAccess.getHiddenLeafsBefore(closingBracket);
       int _newLines = _hiddenLeafsBefore_1.getNewLines();
       return (_newLines > 0);
@@ -1093,8 +1084,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
         final INode featureNode = this._nodeModelAccess.nodeForFeature(call, XbasePackage.Literals.XABSTRACT_FEATURE_CALL__FEATURE);
         XExpression _memberCallTarget = call.getMemberCallTarget();
         final INode targetNode = this._nodeModelAccess.nodeForEObject(_memberCallTarget);
-        boolean _notEquals = (!Objects.equal(targetNode, null));
-        if (_notEquals) {
+        if ((targetNode != null)) {
           final int callOffset = targetNode.getEndOffset();
           String _switchResult = null;
           final XMemberFeatureCall it = call;
@@ -1252,7 +1242,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
   
   protected AbstractRule binaryOperationPrecedence(final EObject op) {
     final INode node = this._nodeModelAccess.nodeForFeature(op, XbasePackage.Literals.XABSTRACT_FEATURE_CALL__FEATURE);
-    if (((!Objects.equal(node, null)) && (node.getGrammarElement() instanceof CrossReference))) {
+    if (((node != null) && (node.getGrammarElement() instanceof CrossReference))) {
       EObject _grammarElement = node.getGrammarElement();
       final AbstractElement terminal = ((CrossReference) _grammarElement).getTerminal();
       if ((terminal instanceof RuleCall)) {
@@ -1265,8 +1255,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
   protected boolean isMultiline(final XExpression expression, final FormattableDocument doc) {
     final INode node = this._nodeModelAccess.nodeForEObject(expression);
     boolean _and = false;
-    boolean _notEquals = (!Objects.equal(node, null));
-    if (!_notEquals) {
+    if (!(node != null)) {
       _and = false;
     } else {
       boolean _xblockexpression = false;
@@ -1539,8 +1528,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
       Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _prepend = this._formattingDataFactory.prepend(thennode, _function_5);
       format.operator_add(_prepend);
       XExpression _else_1 = expr.getElse();
-      boolean _notEquals = (!Objects.equal(_else_1, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_else_1 != null);
+      if (_tripleNotEquals) {
         final Procedure1<FormattingDataInit> _function_6 = (FormattingDataInit it) -> {
           it.cfg(XbaseFormatterPreferenceKeys.bracesInNewLine);
         };
@@ -1555,8 +1544,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
         Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _prepend_1 = this._formattingDataFactory.prepend(thennode, _function_7);
         format.operator_add(_prepend_1);
         XExpression _else_2 = expr.getElse();
-        boolean _notEquals_1 = (!Objects.equal(_else_2, null));
-        if (_notEquals_1) {
+        boolean _tripleNotEquals_1 = (_else_2 != null);
+        if (_tripleNotEquals_1) {
           final Procedure1<FormattingDataInit> _function_8 = (FormattingDataInit it) -> {
             it.oneSpace();
           };
@@ -1571,8 +1560,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
         Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _prepend_2 = this._formattingDataFactory.prepend(thennode, _function_9);
         format.operator_add(_prepend_2);
         XExpression _else_3 = expr.getElse();
-        boolean _notEquals_2 = (!Objects.equal(_else_3, null));
-        if (_notEquals_2) {
+        boolean _tripleNotEquals_2 = (_else_3 != null);
+        if (_tripleNotEquals_2) {
           final Procedure1<FormattingDataInit> _function_10 = (FormattingDataInit it) -> {
             it.newLine();
             it.decreaseIndentation();
@@ -1621,8 +1610,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
     XExpression _then_2 = expr.getThen();
     this.format(_then_2, format);
     XExpression _else_5 = expr.getElse();
-    boolean _notEquals_3 = (!Objects.equal(_else_5, null));
-    if (_notEquals_3) {
+    boolean _tripleNotEquals_3 = (_else_5 != null);
+    if (_tripleNotEquals_3) {
       XExpression _else_6 = expr.getElse();
       this.format(_else_6, format);
     }
@@ -1764,8 +1753,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
       previousFormattedNode = _doubleArrow;
     }
     final XExpression expression = expr.getExpression();
-    boolean _notEquals = (!Objects.equal(expression, null));
-    if (_notEquals) {
+    if ((expression != null)) {
       INode _nodeForEObject = this._nodeModelAccess.nodeForEObject(expression);
       final Procedure1<INode> _function_2 = (INode it) -> {
         final Procedure1<FormattingDataInit> _function_3 = (FormattingDataInit it_1) -> {
@@ -1955,8 +1943,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
   protected void _format(final XBlockExpression expr, final FormattableDocument format) {
     final ILeafNode open = this._nodeModelAccess.nodeForKeyword(expr, "{");
     EObject _eContainer = expr.eContainer();
-    boolean _equals = Objects.equal(_eContainer, null);
-    if (_equals) {
+    boolean _tripleEquals = (_eContainer == null);
+    if (_tripleEquals) {
       final Procedure1<FormattingDataInit> _function = (FormattingDataInit it) -> {
         it.noSpace();
       };
@@ -1964,7 +1952,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
       format.operator_add(_prepend);
     }
     final ILeafNode close = this._nodeModelAccess.nodeForKeyword(expr, "}");
-    if (((!Objects.equal(open, null)) && (!Objects.equal(close, null)))) {
+    if (((open != null) && (close != null))) {
       boolean _isSingleLineBlock = this.isSingleLineBlock(expr, format);
       final boolean multiLine = (!_isSingleLineBlock);
       EList<XExpression> _expressions = expr.getExpressions();
@@ -2018,11 +2006,10 @@ public class XbaseFormatter2 extends AbstractFormatter {
         for (final XExpression child : _expressions_1) {
           {
             this.format(child, format);
-            if (((!Objects.equal(child, IterableExtensions.<XExpression>last(expr.getExpressions()))) || (!Objects.equal(close, null)))) {
+            if (((!Objects.equal(child, IterableExtensions.<XExpression>last(expr.getExpressions()))) || (close != null))) {
               final INode childNode = this._nodeModelAccess.nodeForEObject(child);
               final ILeafNode sem = this._nodeModelAccess.immediatelyFollowingKeyword(childNode, ";");
-              boolean _notEquals = (!Objects.equal(sem, null));
-              if (_notEquals) {
+              if ((sem != null)) {
                 final Procedure1<FormattingDataInit> _function_6 = (FormattingDataInit it) -> {
                   it.noSpace();
                 };
@@ -2085,12 +2072,11 @@ public class XbaseFormatter2 extends AbstractFormatter {
     Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _append_1 = this._formattingDataFactory.append(typeNode, _function_2);
     format.operator_add(_append_1);
     INode node = typeNode;
-    while ((!Objects.equal(node, null))) {
+    while ((node != null)) {
       {
         ILeafNode _immediatelyFollowingKeyword = this._nodeModelAccess.immediatelyFollowingKeyword(node, "[");
         node = _immediatelyFollowingKeyword;
-        boolean _notEquals = (!Objects.equal(node, null));
-        if (_notEquals) {
+        if ((node != null)) {
           final Procedure1<FormattingDataInit> _function_3 = (FormattingDataInit it) -> {
             it.noSpace();
           };
@@ -2098,8 +2084,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
           format.operator_add(_append_2);
           ILeafNode _immediatelyFollowingKeyword_1 = this._nodeModelAccess.immediatelyFollowingKeyword(node, "]");
           node = _immediatelyFollowingKeyword_1;
-          boolean _notEquals_1 = (!Objects.equal(node, null));
-          if (_notEquals_1) {
+          if ((node != null)) {
             final Procedure1<FormattingDataInit> _function_4 = (FormattingDataInit it) -> {
               it.noSpace();
             };
@@ -2170,7 +2155,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
     for (final XCatchClause cc : _catchClauses) {
       {
         this.format(cc, format);
-        if (((!Objects.equal(cc, IterableExtensions.<XCatchClause>last(expr.getCatchClauses()))) || (!Objects.equal(expr.getFinallyExpression(), null)))) {
+        if (((!Objects.equal(cc, IterableExtensions.<XCatchClause>last(expr.getCatchClauses()))) || (expr.getFinallyExpression() != null))) {
           XExpression _expression_3 = cc.getExpression();
           if ((_expression_3 instanceof XBlockExpression)) {
             INode _nodeForEObject = this._nodeModelAccess.nodeForEObject(cc);
@@ -2191,8 +2176,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
       }
     }
     XExpression _finallyExpression = expr.getFinallyExpression();
-    boolean _notEquals = (!Objects.equal(_finallyExpression, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_finallyExpression != null);
+    if (_tripleNotEquals) {
       XExpression _finallyExpression_1 = expr.getFinallyExpression();
       final INode fin = this._nodeModelAccess.nodeForEObject(_finallyExpression_1);
       XExpression _finallyExpression_2 = expr.getFinallyExpression();
@@ -2272,8 +2257,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
   
   protected void _format(final JvmFormalParameter expr, final FormattableDocument format) {
     JvmTypeReference _parameterType = expr.getParameterType();
-    boolean _notEquals = (!Objects.equal(_parameterType, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_parameterType != null);
+    if (_tripleNotEquals) {
       JvmTypeReference _parameterType_1 = expr.getParameterType();
       INode _nodeForEObject = this._nodeModelAccess.nodeForEObject(_parameterType_1);
       final Procedure1<FormattingDataInit> _function = (FormattingDataInit it) -> {
@@ -2306,7 +2291,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
     final boolean containsBlockExpr = IterableExtensions.<XCasePart>exists(_cases, _function);
     final boolean switchSL = ((!containsBlockExpr) && (!this._nodeModelAccess.nodeForEObject(expr).getText().trim().contains("\n")));
     boolean _and = false;
-    if (!(((!containsBlockExpr) && ((!expr.getCases().isEmpty()) || (!Objects.equal(expr.getDefault(), null)))) && (!IterableExtensions.<XCasePart>exists(expr.getCases(), ((Function1<XCasePart, Boolean>) (XCasePart it) -> {
+    if (!(((!containsBlockExpr) && ((!expr.getCases().isEmpty()) || (expr.getDefault() != null))) && (!IterableExtensions.<XCasePart>exists(expr.getCases(), ((Function1<XCasePart, Boolean>) (XCasePart it) -> {
       INode _nodeForEObject = this._nodeModelAccess.nodeForEObject(it);
       String _text = _nodeForEObject.getText();
       String _trim = _text.trim();
@@ -2353,8 +2338,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
       EList<XCasePart> _cases_1 = expr.getCases();
       for (final XCasePart c : _cases_1) {
         XExpression _then = c.getThen();
-        boolean _equals = Objects.equal(_then, null);
-        if (_equals) {
+        boolean _tripleEquals = (_then == null);
+        if (_tripleEquals) {
           INode _nodeForEObject_1 = this._nodeModelAccess.nodeForEObject(c);
           final Procedure1<FormattingDataInit> _function_4 = (FormattingDataInit it) -> {
             it.oneSpace();
@@ -2377,8 +2362,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
         }
       }
       XExpression _default_1 = expr.getDefault();
-      boolean _notEquals = (!Objects.equal(_default_1, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_default_1 != null);
+      if (_tripleNotEquals) {
         ILeafNode _nodeForKeyword_1 = this._nodeModelAccess.nodeForKeyword(expr, "default");
         final Procedure1<FormattingDataInit> _function_7 = (FormattingDataInit it) -> {
           it.noSpace();
@@ -2427,8 +2412,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
             format.operator_add(_prepend_3);
             EList<XCasePart> _cases_4 = expr.getCases();
             XCasePart _last = IterableExtensions.<XCasePart>last(_cases_4);
-            boolean _notEquals_1 = (!Objects.equal(c_1, _last));
-            if (_notEquals_1) {
+            boolean _notEquals = (!Objects.equal(c_1, _last));
+            if (_notEquals) {
               INode _nodeForEObject_4 = this._nodeModelAccess.nodeForEObject(c_1);
               final Procedure1<FormattingDataInit> _function_13 = (FormattingDataInit it) -> {
                 it.newLine();
@@ -2439,8 +2424,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
           }
         }
         XExpression _default_3 = expr.getDefault();
-        boolean _notEquals_1 = (!Objects.equal(_default_3, null));
-        if (_notEquals_1) {
+        boolean _tripleNotEquals_1 = (_default_3 != null);
+        if (_tripleNotEquals_1) {
           ILeafNode _nodeForKeyword_2 = this._nodeModelAccess.nodeForKeyword(expr, "default");
           final Procedure1<FormattingDataInit> _function_12 = (FormattingDataInit it) -> {
             it.newLine();
@@ -2475,7 +2460,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
         };
         Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _append_7 = this._formattingDataFactory.append(open, _function_17);
         format.operator_add(_append_7);
-        if (((!expr.getCases().isEmpty()) || (!Objects.equal(expr.getDefault(), null)))) {
+        if (((!expr.getCases().isEmpty()) || (expr.getDefault() != null))) {
           final Procedure1<FormattingDataInit> _function_18 = (FormattingDataInit it) -> {
             it.increaseIndentation();
           };
@@ -2502,7 +2487,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
               };
               Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _prepend_6 = this._formattingDataFactory.prepend(cnode_1, _function_19);
               format.operator_add(_prepend_6);
-              if (((!Objects.equal(expr.getDefault(), null)) || (!Objects.equal(c_2, IterableExtensions.<XCasePart>last(expr.getCases()))))) {
+              if (((expr.getDefault() != null) || (!Objects.equal(c_2, IterableExtensions.<XCasePart>last(expr.getCases()))))) {
                 final Procedure1<FormattingDataInit> _function_20 = (FormattingDataInit it) -> {
                   it.newLine();
                 };
@@ -2532,7 +2517,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
                 Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _prepend_7 = this._formattingDataFactory.prepend(cnode_1, _function_23);
                 format.operator_add(_prepend_7);
               }
-              if (((!Objects.equal(expr.getDefault(), null)) || (!Objects.equal(c_2, IterableExtensions.<XCasePart>last(expr.getCases()))))) {
+              if (((expr.getDefault() != null) || (!Objects.equal(c_2, IterableExtensions.<XCasePart>last(expr.getCases()))))) {
                 final Procedure1<FormattingDataInit> _function_24 = (FormattingDataInit it) -> {
                   it.newLine();
                   it.decreaseIndentation();
@@ -2551,8 +2536,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
           }
         }
         XExpression _default_5 = expr.getDefault();
-        boolean _notEquals_2 = (!Objects.equal(_default_5, null));
-        if (_notEquals_2) {
+        boolean _tripleNotEquals_2 = (_default_5 != null);
+        if (_tripleNotEquals_2) {
           ILeafNode _nodeForKeyword_3 = this._nodeModelAccess.nodeForKeyword(expr, "default");
           final Procedure1<FormattingDataInit> _function_19 = (FormattingDataInit it) -> {
             it.noSpace();
@@ -2592,7 +2577,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
     EList<XCasePart> _cases_5 = expr.getCases();
     for (final XCasePart c_3 : _cases_5) {
       {
-        if (((!Objects.equal(c_3.getTypeGuard(), null)) && (!Objects.equal(c_3.getCase(), null)))) {
+        if (((c_3.getTypeGuard() != null) && (c_3.getCase() != null))) {
           final INode typenode = this._nodeModelAccess.nodeForFeature(c_3, XbasePackage.Literals.XCASE_PART__TYPE_GUARD);
           final INode casenode = this._nodeModelAccess.nodeForFeature(c_3, XbasePackage.Literals.XCASE_PART__CASE);
           final Procedure1<FormattingDataInit> _function_24 = (FormattingDataInit it) -> {
@@ -2612,8 +2597,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
           format.operator_add(_append_11);
         } else {
           JvmTypeReference _typeGuard = c_3.getTypeGuard();
-          boolean _notEquals_3 = (!Objects.equal(_typeGuard, null));
-          if (_notEquals_3) {
+          boolean _tripleNotEquals_3 = (_typeGuard != null);
+          if (_tripleNotEquals_3) {
             final INode typenode_1 = this._nodeModelAccess.nodeForFeature(c_3, XbasePackage.Literals.XCASE_PART__TYPE_GUARD);
             final Procedure1<FormattingDataInit> _function_27 = (FormattingDataInit it) -> {
               it.noSpace();
@@ -2622,8 +2607,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
             format.operator_add(_append_12);
           } else {
             XExpression _case = c_3.getCase();
-            boolean _notEquals_4 = (!Objects.equal(_case, null));
-            if (_notEquals_4) {
+            boolean _tripleNotEquals_4 = (_case != null);
+            if (_tripleNotEquals_4) {
               final INode casenode_1 = this._nodeModelAccess.nodeForFeature(c_3, XbasePackage.Literals.XCASE_PART__CASE);
               final Procedure1<FormattingDataInit> _function_28 = (FormattingDataInit it) -> {
                 it.oneSpace();
@@ -2645,8 +2630,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
       }
     }
     XExpression _default_9 = expr.getDefault();
-    boolean _notEquals_3 = (!Objects.equal(_default_9, null));
-    if (_notEquals_3) {
+    boolean _tripleNotEquals_3 = (_default_9 != null);
+    if (_tripleNotEquals_3) {
       XExpression _default_10 = expr.getDefault();
       this.format(_default_10, format);
     }
@@ -2698,8 +2683,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
   protected void formatClosureMultiLine(final XClosure expr, final INode open, final Collection<XExpression> children, final INode close, final FormattableDocument format) {
     this.formatClosureParameters(expr, format);
     final INode explicit = this._nodeModelAccess.nodeForFeature(expr, XbasePackage.Literals.XCLOSURE__EXPLICIT_SYNTAX);
-    boolean _notEquals = (!Objects.equal(explicit, null));
-    if (_notEquals) {
+    if ((explicit != null)) {
       EList<JvmFormalParameter> _declaredFormalParameters = expr.getDeclaredFormalParameters();
       boolean _isEmpty = _declaredFormalParameters.isEmpty();
       if (_isEmpty) {
@@ -2745,8 +2729,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
         Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _prepend_2 = this._formattingDataFactory.prepend(semicolon, _function_5);
         format.operator_add(_prepend_2);
         XExpression _last = IterableExtensions.<XExpression>last(children);
-        boolean _notEquals_1 = (!Objects.equal(c, _last));
-        if (_notEquals_1) {
+        boolean _notEquals = (!Objects.equal(c, _last));
+        if (_notEquals) {
           INode _elvis = null;
           if (semicolon != null) {
             _elvis = semicolon;
@@ -2848,8 +2832,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
         INode _nodeForEObject = this._nodeModelAccess.nodeForEObject(c);
         last = _nodeForEObject;
         final ILeafNode semicolon = this._nodeModelAccess.immediatelyFollowingKeyword(last, ";");
-        boolean _notEquals = (!Objects.equal(semicolon, null));
-        if (_notEquals) {
+        if ((semicolon != null)) {
           final Procedure1<FormattingDataInit> _function_5 = (FormattingDataInit it) -> {
             it.noSpace();
           };

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/ObjectEntry.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/ObjectEntry.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.formatting2;
 
-import com.google.common.base.Objects;
 import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
 import org.eclipse.xtend2.lib.StringConcatenation;
@@ -34,8 +33,7 @@ public class ObjectEntry<T extends Object, R extends ITextSegment> extends Entry
     final SeparatorEntry<T, R> prev = this.getLeadingSeparator();
     final SeparatorEntry<T, R> trail = this.getTrailingSeparator();
     int _xifexpression = (int) 0;
-    boolean _notEquals = (!Objects.equal(prev, null));
-    if (_notEquals) {
+    if ((prev != null)) {
       R _separator = prev.getSeparator();
       _xifexpression = _separator.getEndOffset();
     } else {
@@ -44,8 +42,7 @@ public class ObjectEntry<T extends Object, R extends ITextSegment> extends Entry
     }
     final int offset = _xifexpression;
     int _xifexpression_1 = (int) 0;
-    boolean _notEquals_1 = (!Objects.equal(trail, null));
-    if (_notEquals_1) {
+    if ((trail != null)) {
       R _separator_1 = trail.getSeparator();
       _xifexpression_1 = _separator_1.getOffset();
     } else {

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/SeparatorRegions.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/SeparatorRegions.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.formatting2;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.AbstractIterator;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -35,8 +34,7 @@ public class SeparatorRegions<T extends Object, R extends ITextSegment> implemen
   public void prepend(final T object) {
     final ObjectEntry<T, R> newObject = new ObjectEntry<T, R>(this);
     newObject.setObject(object);
-    boolean _equals = Objects.equal(this.first, null);
-    if (_equals) {
+    if ((this.first == null)) {
       this.first = newObject;
     } else {
       SeparatorEntry<T, R> _leadingSeparator = this.first.getLeadingSeparator();
@@ -54,8 +52,7 @@ public class SeparatorRegions<T extends Object, R extends ITextSegment> implemen
     newSeparator.setSeparator(separator);
     newObject.previous = newSeparator;
     newSeparator.next = newObject;
-    boolean _equals = Objects.equal(this.first, null);
-    if (_equals) {
+    if ((this.first == null)) {
       this.first = newObject;
     } else {
       SeparatorEntry<T, R> _leadingSeparator = this.first.getLeadingSeparator();
@@ -69,15 +66,13 @@ public class SeparatorRegions<T extends Object, R extends ITextSegment> implemen
   public void appendWithTrailingSeparator(final T object, final R separator) {
     final ObjectEntry<T, R> newObject = new ObjectEntry<T, R>(this);
     newObject.setObject(object);
-    boolean _notEquals = (!Objects.equal(separator, null));
-    if (_notEquals) {
+    if ((separator != null)) {
       final SeparatorEntry<T, R> newSeparator = new SeparatorEntry<T, R>();
       newSeparator.setSeparator(separator);
       newObject.next = newSeparator;
       newSeparator.previous = newObject;
     }
-    boolean _equals = Objects.equal(this.first, null);
-    if (_equals) {
+    if ((this.first == null)) {
       this.first = newObject;
     } else {
       Iterable<SeparatorEntry<T, R>> _separators = this.separators();
@@ -101,8 +96,7 @@ public class SeparatorRegions<T extends Object, R extends ITextSegment> implemen
       protected ObjectEntry<T, R> computeNext() {
         ObjectEntry<T, R> _xblockexpression = null;
         {
-          boolean _equals = Objects.equal(this.next, null);
-          if (_equals) {
+          if ((this.next == null)) {
             return this.endOfData();
           }
           final ObjectEntry<T, R> current = this.next;
@@ -131,8 +125,7 @@ public class SeparatorRegions<T extends Object, R extends ITextSegment> implemen
           protected SeparatorEntry<T, R> computeNext() {
             SeparatorEntry<T, R> _xblockexpression = null;
             {
-              boolean _equals = Objects.equal(this.next, null);
-              if (_equals) {
+              if ((this.next == null)) {
                 return this.endOfData();
               }
               final SeparatorEntry<T, R> current = this.next;
@@ -150,13 +143,12 @@ public class SeparatorRegions<T extends Object, R extends ITextSegment> implemen
   @Override
   public String toString() {
     String _xifexpression = null;
-    boolean _notEquals = (!Objects.equal(this.first, null));
-    if (_notEquals) {
+    if ((this.first != null)) {
       String _xblockexpression = null;
       {
         final ArrayList<String> list = CollectionLiterals.<String>newArrayList();
         Entry<T, R> current = this.first.getLeadingSeparator();
-        while ((!Objects.equal(current, null))) {
+        while ((current != null)) {
           {
             String _string = current.toString();
             list.add(_string);

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.java
@@ -131,7 +131,7 @@ public class XbaseFormatter extends XtypeFormatter {
   }
   
   protected void formatCommaSeparatedList(final Collection<? extends EObject> elements, final ISemanticRegion open, final ISemanticRegion close, @Extension final IFormattableDocument format) {
-    if ((Objects.equal(close, null) || Objects.equal(open, null))) {
+    if (((close == null) || (open == null))) {
     } else {
       boolean _isEmpty = elements.isEmpty();
       if (_isEmpty) {
@@ -197,8 +197,7 @@ public class XbaseFormatter extends XtypeFormatter {
               EObject _object = ele_1.getObject();
               boolean _prependNewLineIfMultiline = this.prependNewLineIfMultiline(_object);
               if (_prependNewLineIfMultiline) {
-                boolean _equals = Objects.equal(sep, null);
-                if (_equals) {
+                if ((sep == null)) {
                   final Procedure1<IHiddenRegionFormatter> _function_4 = (IHiddenRegionFormatter it) -> {
                     it.noSpace();
                     ITextSegment _region = ele_1.getRegion();
@@ -325,8 +324,7 @@ public class XbaseFormatter extends XtypeFormatter {
   }
   
   protected void formatBuilderWithLeadingGap(final XClosure closure, @Extension final IFormattableDocument format) {
-    boolean _notEquals = (!Objects.equal(closure, null));
-    if (_notEquals) {
+    if ((closure != null)) {
       IHiddenRegion _previousHiddenRegion = this.textRegionExtensions.previousHiddenRegion(closure);
       final int offset = _previousHiddenRegion.getOffset();
       IHiddenRegion _nextHiddenRegion = this.textRegionExtensions.nextHiddenRegion(closure);
@@ -355,8 +353,8 @@ public class XbaseFormatter extends XtypeFormatter {
   protected XClosure builder(final List<XExpression> params) {
     XClosure _xifexpression = null;
     XExpression _last = IterableExtensions.<XExpression>last(params);
-    boolean _notEquals = (!Objects.equal(_last, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_last != null);
+    if (_tripleNotEquals) {
       XClosure _xblockexpression = null;
       {
         XExpression _last_1 = IterableExtensions.<XExpression>last(params);
@@ -380,8 +378,7 @@ public class XbaseFormatter extends XtypeFormatter {
     {
       final XClosure builder = this.builder(params);
       Iterable<XExpression> _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(builder, null));
-      if (_notEquals) {
+      if ((builder != null)) {
         int _size = params.size();
         int _minus = (_size - 1);
         _xifexpression = IterableExtensions.<XExpression>take(params, _minus);
@@ -546,8 +543,7 @@ public class XbaseFormatter extends XtypeFormatter {
         this.formatFeatureCallTypeParameters(call, format);
         ISemanticRegionsFinder _regionFor = this.textRegionExtensions.regionFor(call);
         final ISemanticRegion feature = _regionFor.feature(XbasePackage.Literals.XABSTRACT_FEATURE_CALL__FEATURE);
-        boolean _notEquals = (!Objects.equal(feature, null));
-        if (_notEquals) {
+        if ((feature != null)) {
           ITextSegment _region = entry.getRegion();
           int _length = _region.getLength();
           int _length_1 = feature.getLength();
@@ -593,7 +589,7 @@ public class XbaseFormatter extends XtypeFormatter {
   protected AbstractRule binaryOperationPrecedence(final EObject op) {
     ISemanticRegionsFinder _regionFor = this.textRegionExtensions.regionFor(op);
     final ISemanticRegion node = _regionFor.feature(XbasePackage.Literals.XABSTRACT_FEATURE_CALL__FEATURE);
-    if (((!Objects.equal(node, null)) && (node.getGrammarElement() instanceof RuleCall))) {
+    if (((node != null) && (node.getGrammarElement() instanceof RuleCall))) {
       EObject _grammarElement = node.getGrammarElement();
       return ((RuleCall) _grammarElement).getRule();
     }
@@ -735,8 +731,8 @@ public class XbaseFormatter extends XtypeFormatter {
     XExpression _if_1 = expr.getIf();
     format.<XExpression>format(_if_1);
     XExpression _else = expr.getElse();
-    boolean _equals = Objects.equal(_else, null);
-    if (_equals) {
+    boolean _tripleEquals = (_else == null);
+    if (_tripleEquals) {
       XExpression _then = expr.getThen();
       this.formatBody(_then, multiline, format);
     } else {
@@ -902,14 +898,14 @@ public class XbaseFormatter extends XtypeFormatter {
     ISemanticRegionsFinder _regionFor_1 = this.textRegionExtensions.regionFor(expr);
     final ISemanticRegion close = _regionFor_1.keyword("}");
     EObject _eContainer = expr.eContainer();
-    boolean _equals = Objects.equal(_eContainer, null);
-    if (_equals) {
+    boolean _tripleEquals = (_eContainer == null);
+    if (_tripleEquals) {
       final Procedure1<IHiddenRegionFormatter> _function = (IHiddenRegionFormatter it) -> {
         it.noSpace();
       };
       format.<XBlockExpression>surround(expr, _function);
     }
-    if (((!Objects.equal(open, null)) && (!Objects.equal(close, null)))) {
+    if (((open != null) && (close != null))) {
       boolean _isSingleLineBlock = this.isSingleLineBlock(expr);
       if (_isSingleLineBlock) {
         final ISubFormatter _function_1 = (IFormattableSubDocument f) -> {
@@ -1004,7 +1000,7 @@ public class XbaseFormatter extends XtypeFormatter {
         };
         JvmFormalParameter _append = format.<JvmFormalParameter>append(_prepend, _function_1);
         format.<JvmFormalParameter>format(_append);
-        if (((!Objects.equal(cc, IterableExtensions.<XCatchClause>last(expr.getCatchClauses()))) || (!Objects.equal(expr.getFinallyExpression(), null)))) {
+        if (((!Objects.equal(cc, IterableExtensions.<XCatchClause>last(expr.getCatchClauses()))) || (expr.getFinallyExpression() != null))) {
           XExpression _expression_1 = cc.getExpression();
           this.formatBodyInline(_expression_1, true, format);
         } else {
@@ -1048,7 +1044,7 @@ public class XbaseFormatter extends XtypeFormatter {
     };
     final boolean containsBlockExpr = IterableExtensions.<XCasePart>exists(_cases, _function);
     final boolean switchSL = ((!containsBlockExpr) && (!this.textRegionExtensions.isMultiline(expr)));
-    final boolean caseSL = ((((!containsBlockExpr) && ((!expr.getCases().isEmpty()) || (!Objects.equal(expr.getDefault(), null)))) && 
+    final boolean caseSL = ((((!containsBlockExpr) && ((!expr.getCases().isEmpty()) || (expr.getDefault() != null))) && 
       (!IterableExtensions.<XCasePart>exists(expr.getCases(), ((Function1<XCasePart, Boolean>) (XCasePart it) -> {
         return Boolean.valueOf(this.textRegionExtensions.isMultiline(it));
       })))) && (!this.isMultilineOrInNewLine(expr.getDefault())));
@@ -1079,8 +1075,8 @@ public class XbaseFormatter extends XtypeFormatter {
           XExpression _then = c.getThen();
           format.<XExpression>format(_then);
           XExpression _then_1 = c.getThen();
-          boolean _equals = Objects.equal(_then_1, null);
-          if (_equals) {
+          boolean _tripleEquals = (_then_1 == null);
+          if (_tripleEquals) {
             final Procedure1<IHiddenRegionFormatter> _function_4 = (IHiddenRegionFormatter it) -> {
               it.oneSpace();
             };
@@ -1099,8 +1095,8 @@ public class XbaseFormatter extends XtypeFormatter {
         }
       }
       XExpression _default = expr.getDefault();
-      boolean _notEquals = (!Objects.equal(_default, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_default != null);
+      if (_tripleNotEquals) {
         ISemanticRegionsFinder _regionFor_3 = this.textRegionExtensions.regionFor(expr);
         ISemanticRegion _keyword_1 = _regionFor_3.keyword("default");
         final Procedure1<IHiddenRegionFormatter> _function_4 = (IHiddenRegionFormatter it) -> {
@@ -1144,8 +1140,8 @@ public class XbaseFormatter extends XtypeFormatter {
             format.<XExpression>prepend(_then_1, _function_8);
             EList<XCasePart> _cases_4 = expr.getCases();
             XCasePart _last = IterableExtensions.<XCasePart>last(_cases_4);
-            boolean _notEquals_1 = (!Objects.equal(c_1, _last));
-            if (_notEquals_1) {
+            boolean _notEquals = (!Objects.equal(c_1, _last));
+            if (_notEquals) {
               final Procedure1<IHiddenRegionFormatter> _function_9 = (IHiddenRegionFormatter it) -> {
                 it.newLine();
               };
@@ -1154,8 +1150,8 @@ public class XbaseFormatter extends XtypeFormatter {
           }
         }
         XExpression _default_2 = expr.getDefault();
-        boolean _notEquals_1 = (!Objects.equal(_default_2, null));
-        if (_notEquals_1) {
+        boolean _tripleNotEquals_1 = (_default_2 != null);
+        if (_tripleNotEquals_1) {
           ISemanticRegionsFinder _regionFor_4 = this.textRegionExtensions.regionFor(expr);
           ISemanticRegion _keyword_2 = _regionFor_4.keyword("default");
           final Procedure1<IHiddenRegionFormatter> _function_8 = (IHiddenRegionFormatter it) -> {
@@ -1183,7 +1179,7 @@ public class XbaseFormatter extends XtypeFormatter {
           it.newLine();
         };
         format.append(_prepend_2, _function_12);
-        if (((!expr.getCases().isEmpty()) || (!Objects.equal(expr.getDefault(), null)))) {
+        if (((!expr.getCases().isEmpty()) || (expr.getDefault() != null))) {
           final Procedure1<IHiddenRegionFormatter> _function_13 = (IHiddenRegionFormatter it) -> {
             it.indent();
           };
@@ -1209,8 +1205,8 @@ public class XbaseFormatter extends XtypeFormatter {
           }
         }
         XExpression _default_4 = expr.getDefault();
-        boolean _notEquals_2 = (!Objects.equal(_default_4, null));
-        if (_notEquals_2) {
+        boolean _tripleNotEquals_2 = (_default_4 != null);
+        if (_tripleNotEquals_2) {
           ISemanticRegionsFinder _regionFor_5 = this.textRegionExtensions.regionFor(expr);
           ISemanticRegion _keyword_3 = _regionFor_5.keyword("default");
           final Procedure1<IHiddenRegionFormatter> _function_14 = (IHiddenRegionFormatter it) -> {
@@ -1224,7 +1220,7 @@ public class XbaseFormatter extends XtypeFormatter {
     }
     EList<XCasePart> _cases_5 = expr.getCases();
     for (final XCasePart c_3 : _cases_5) {
-      if (((!Objects.equal(c_3.getTypeGuard(), null)) && (!Objects.equal(c_3.getCase(), null)))) {
+      if (((c_3.getTypeGuard() != null) && (c_3.getCase() != null))) {
         JvmTypeReference _typeGuard = c_3.getTypeGuard();
         final Procedure1<IHiddenRegionFormatter> _function_15 = (IHiddenRegionFormatter it) -> {
           it.oneSpace();
@@ -1241,8 +1237,8 @@ public class XbaseFormatter extends XtypeFormatter {
         format.<XExpression>append(_prepend_3, _function_17);
       } else {
         JvmTypeReference _typeGuard_1 = c_3.getTypeGuard();
-        boolean _notEquals_3 = (!Objects.equal(_typeGuard_1, null));
-        if (_notEquals_3) {
+        boolean _tripleNotEquals_3 = (_typeGuard_1 != null);
+        if (_tripleNotEquals_3) {
           JvmTypeReference _typeGuard_2 = c_3.getTypeGuard();
           final Procedure1<IHiddenRegionFormatter> _function_18 = (IHiddenRegionFormatter it) -> {
             it.noSpace();
@@ -1250,8 +1246,8 @@ public class XbaseFormatter extends XtypeFormatter {
           format.<JvmTypeReference>append(_typeGuard_2, _function_18);
         } else {
           XExpression _case_1 = c_3.getCase();
-          boolean _notEquals_4 = (!Objects.equal(_case_1, null));
-          if (_notEquals_4) {
+          boolean _tripleNotEquals_4 = (_case_1 != null);
+          if (_tripleNotEquals_4) {
             XExpression _case_2 = c_3.getCase();
             final Procedure1<IHiddenRegionFormatter> _function_19 = (IHiddenRegionFormatter it) -> {
               it.oneSpace();
@@ -1344,7 +1340,7 @@ public class XbaseFormatter extends XtypeFormatter {
       _switchResult = CollectionLiterals.<XExpression>newArrayList(x);
     }
     final List<XExpression> children = _switchResult;
-    if ((Objects.equal(open, null) || Objects.equal(close, null))) {
+    if (((open == null) || (close == null))) {
     } else {
       boolean _isEmpty = children.isEmpty();
       if (_isEmpty) {
@@ -1393,8 +1389,7 @@ public class XbaseFormatter extends XtypeFormatter {
                 it.<XExpression>format(c);
                 ISemanticRegionFinder _immediatelyFollowing_1 = this.textRegionExtensions.immediatelyFollowing(c);
                 final ISemanticRegion semicolon = _immediatelyFollowing_1.keyword(";");
-                boolean _notEquals = (!Objects.equal(semicolon, null));
-                if (_notEquals) {
+                if ((semicolon != null)) {
                   final Procedure1<IHiddenRegionFormatter> _function_6 = (IHiddenRegionFormatter it_1) -> {
                     it_1.noSpace();
                   };
@@ -1438,8 +1433,7 @@ public class XbaseFormatter extends XtypeFormatter {
   }
   
   protected void formatBody(final XExpression expr, final boolean forceMultiline, @Extension final IFormattableDocument doc) {
-    boolean _equals = Objects.equal(expr, null);
-    if (_equals) {
+    if ((expr == null)) {
       return;
     }
     if ((expr instanceof XBlockExpression)) {
@@ -1465,8 +1459,7 @@ public class XbaseFormatter extends XtypeFormatter {
   }
   
   protected void formatBodyInline(final XExpression expr, final boolean forceMultiline, @Extension final IFormattableDocument doc) {
-    boolean _equals = Objects.equal(expr, null);
-    if (_equals) {
+    if ((expr == null)) {
       return;
     }
     if ((expr instanceof XBlockExpression)) {
@@ -1497,8 +1490,7 @@ public class XbaseFormatter extends XtypeFormatter {
   }
   
   protected void formatBodyParagraph(final XExpression expr, @Extension final IFormattableDocument doc) {
-    boolean _equals = Objects.equal(expr, null);
-    if (_equals) {
+    if ((expr == null)) {
       return;
     }
     if ((expr instanceof XBlockExpression)) {
@@ -1579,8 +1571,7 @@ public class XbaseFormatter extends XtypeFormatter {
           format.<XExpression>format(child);
           ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(child);
           final ISemanticRegion sem = _immediatelyFollowing.keyword(";");
-          boolean _notEquals = (!Objects.equal(sem, null));
-          if (_notEquals) {
+          if ((sem != null)) {
             final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it) -> {
               it.noSpace();
             };
@@ -1611,8 +1602,7 @@ public class XbaseFormatter extends XtypeFormatter {
           format.<XExpression>format(child);
           ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(child);
           final ISemanticRegion sem = _immediatelyFollowing.keyword(";");
-          boolean _notEquals = (!Objects.equal(sem, null));
-          if (_notEquals) {
+          if ((sem != null)) {
             final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it) -> {
               it.noSpace();
             };
@@ -1633,7 +1623,7 @@ public class XbaseFormatter extends XtypeFormatter {
   }
   
   protected boolean isMultilineOrInNewLine(final EObject obj) {
-    return ((!Objects.equal(obj, null)) && (this.textRegionExtensions.isMultiline(obj) || this.textRegionExtensions.previousHiddenRegion(obj).isMultiline()));
+    return ((obj != null) && (this.textRegionExtensions.isMultiline(obj) || this.textRegionExtensions.previousHiddenRegion(obj).isMultiline()));
   }
   
   public void format(final Object expr, final IFormattableDocument format) {

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/imports/ImportsCollector.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/imports/ImportsCollector.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.xbase.imports;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Arrays;
 import java.util.List;
@@ -62,8 +61,7 @@ public class ImportsCollector {
         boolean _contains = selectedRegion.contains(nodeRegion);
         if (_contains) {
           final EObject semanticElement = node.getSemanticElement();
-          boolean _notEquals = (!Objects.equal(semanticElement, null));
-          if (_notEquals) {
+          if ((semanticElement != null)) {
             ICompositeNode _findActualNodeFor_1 = NodeModelUtils.findActualNodeFor(semanticElement);
             this.visit(semanticElement, _findActualNodeFor_1, acceptor);
           }
@@ -83,7 +81,7 @@ public class ImportsCollector {
     int _offset_1 = textRegion.getOffset();
     int _length = textRegion.getLength();
     final int endOffset = (_offset_1 + _length);
-    while (((!Objects.equal(actualOffsetNode.getParent(), null)) && (actualOffsetNode.getTotalEndOffset() < endOffset))) {
+    while (((actualOffsetNode.getParent() != null) && (actualOffsetNode.getTotalEndOffset() < endOffset))) {
       ICompositeNode _parent = actualOffsetNode.getParent();
       actualOffsetNode = _parent;
     }
@@ -145,22 +143,21 @@ public class ImportsCollector {
   
   protected void _visit(final JvmDeclaredType jvmType, final INode originNode, final ImportsAcceptor acceptor) {
     JvmDeclaredType _declaringType = jvmType.getDeclaringType();
-    boolean _equals = Objects.equal(_declaringType, null);
-    if (_equals) {
+    boolean _tripleEquals = (_declaringType == null);
+    if (_tripleEquals) {
       this.collectTypeImportFrom(jvmType, acceptor);
     }
     final String text = NodeModelUtils.getTokenText(originNode);
     final String outerSegment = this.getFirstNameSegment(text);
     final JvmDeclaredType outerType = this.findDeclaringTypeBySimpleName(jvmType, outerSegment);
-    boolean _equals_1 = Objects.equal(outerType, null);
-    if (_equals_1) {
+    if ((outerType == null)) {
       throw new IllegalStateException();
     }
     this.collectTypeImportFrom(outerType, acceptor);
   }
   
   private JvmDeclaredType findDeclaringTypeBySimpleName(final JvmDeclaredType referencedType, final String outerSegment) {
-    if ((Objects.equal(referencedType.getDeclaringType(), null) || outerSegment.equals(referencedType.getSimpleName()))) {
+    if (((referencedType.getDeclaringType() == null) || outerSegment.equals(referencedType.getSimpleName()))) {
       return referencedType;
     }
     JvmDeclaredType _declaringType = referencedType.getDeclaringType();
@@ -266,8 +263,7 @@ public class ImportsCollector {
           QualifiedName _create = QualifiedName.create(docTypeText);
           IEObjectDescription singleElement = scope.getSingleElement(_create);
           JvmType referencedType = null;
-          boolean _notEquals = (!Objects.equal(singleElement, null));
-          if (_notEquals) {
+          if ((singleElement != null)) {
             EObject _eObjectOrProxy = singleElement.getEObjectOrProxy();
             referencedType = ((JvmType) _eObjectOrProxy);
           }

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/imports/StaticallyImportedMemberProvider.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/imports/StaticallyImportedMemberProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.imports;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.List;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -44,7 +43,7 @@ public class StaticallyImportedMemberProvider {
     Iterable<JvmFeature> _xblockexpression = null;
     {
       final JvmDeclaredType importedType = it.getImportedType();
-      if (((!it.isStatic()) || Objects.equal(importedType, null))) {
+      if (((!it.isStatic()) || (importedType == null))) {
         return CollectionLiterals.<JvmFeature>emptyList();
       }
       Resource _eResource = it.eResource();
@@ -52,7 +51,7 @@ public class StaticallyImportedMemberProvider {
       final IResolvedFeatures resolvedFeatures = this._provider.getResolvedFeatures(importedType);
       List<JvmFeature> _allFeatures = resolvedFeatures.getAllFeatures();
       final Function1<JvmFeature, Boolean> _function = (JvmFeature feature) -> {
-        return Boolean.valueOf(((feature.isStatic() && visibilityHelper.isVisible(feature)) && (Objects.equal(it.getMemberName(), null) || feature.getSimpleName().startsWith(it.getMemberName()))));
+        return Boolean.valueOf(((feature.isStatic() && visibilityHelper.isVisible(feature)) && ((it.getMemberName() == null) || feature.getSimpleName().startsWith(it.getMemberName()))));
       };
       _xblockexpression = IterableExtensions.<JvmFeature>filter(_allFeatures, _function);
     }
@@ -71,7 +70,7 @@ public class StaticallyImportedMemberProvider {
   public Iterable<JvmFeature> getAllFeatures(final Resource resource, final JvmDeclaredType importedType, final boolean static_, final boolean extension, final String memberName) {
     Iterable<JvmFeature> _xblockexpression = null;
     {
-      if (((!static_) || Objects.equal(importedType, null))) {
+      if (((!static_) || (importedType == null))) {
         return CollectionLiterals.<JvmFeature>emptyList();
       }
       final IVisibilityHelper visibilityHelper = this.getVisibilityHelper(resource);
@@ -94,8 +93,7 @@ public class StaticallyImportedMemberProvider {
       {
         final String packageName = this._iImportsConfiguration.getPackageName(((XtextResource)resource));
         IVisibilityHelper _xifexpression = null;
-        boolean _equals = Objects.equal(packageName, null);
-        if (_equals) {
+        if ((packageName == null)) {
           _xifexpression = this.visibilityHelper;
         } else {
           _xifexpression = new ContextualVisibilityHelper(this.visibilityHelper, packageName);

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/interpreter/AbstractConstantExpressionsInterpreter.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/interpreter/AbstractConstantExpressionsInterpreter.java
@@ -117,8 +117,7 @@ public class AbstractConstantExpressionsInterpreter {
   }
   
   protected JvmTypeReference toTypeReference(final JvmType type, final int arrayDimensions) {
-    boolean _equals = Objects.equal(type, null);
-    if (_equals) {
+    if ((type == null)) {
       return null;
     }
     JvmParameterizedTypeReference _createJvmParameterizedTypeReference = TypesFactory.eINSTANCE.createJvmParameterizedTypeReference();

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/interpreter/SwitchConstantExpressionsInterpreter.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/interpreter/SwitchConstantExpressionsInterpreter.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.interpreter;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -112,8 +111,7 @@ public class SwitchConstantExpressionsInterpreter extends AbstractConstantExpres
         } else {
           if ((((JvmField)feature).isFinal() && (((JvmField)feature).isStatic() || ((ctx instanceof SwitchConstantExpressionsInterpreter.SwitchContext) && ((SwitchConstantExpressionsInterpreter.SwitchContext) ctx).validationMode)))) {
             final XExpression associatedExpression = this._iLogicalContainerProvider.getAssociatedExpression(feature);
-            boolean _notEquals = (!Objects.equal(associatedExpression, null));
-            if (_notEquals) {
+            if ((associatedExpression != null)) {
               return this.evaluateAssociatedExpression(associatedExpression, ctx);
             }
           }
@@ -122,7 +120,7 @@ public class SwitchConstantExpressionsInterpreter extends AbstractConstantExpres
     }
     if (!_matched) {
       if (feature instanceof XVariableDeclaration) {
-        if (((!((XVariableDeclaration)feature).isWriteable()) && (!Objects.equal(((XVariableDeclaration)feature).getRight(), null)))) {
+        if (((!((XVariableDeclaration)feature).isWriteable()) && (((XVariableDeclaration)feature).getRight() != null))) {
           _matched=true;
           XExpression _right = ((XVariableDeclaration)feature).getRight();
           return this.evaluateAssociatedExpression(_right, ctx);
@@ -137,8 +135,8 @@ public class SwitchConstantExpressionsInterpreter extends AbstractConstantExpres
         boolean _matched_1 = false;
         if (container instanceof XSwitchExpression) {
           XExpression _switch = ((XSwitchExpression)container).getSwitch();
-          boolean _notEquals = (!Objects.equal(_switch, null));
-          if (_notEquals) {
+          boolean _tripleNotEquals = (_switch != null);
+          if (_tripleNotEquals) {
             _matched_1=true;
             XExpression _switch_1 = ((XSwitchExpression)container).getSwitch();
             return this.evaluate(_switch_1, ctx);

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/jvmmodel/JvmTypeExtensions.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/jvmmodel/JvmTypeExtensions.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.jvmmodel;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import org.eclipse.emf.common.notify.Adapter;
@@ -63,9 +62,9 @@ public class JvmTypeExtensions {
   
   public boolean isSingleSyntheticDefaultConstructor(final JvmConstructor it) {
     return ((((it.getParameters().isEmpty() && 
-      Objects.equal(this._iLogicalContainerProvider.getAssociatedExpression(it), null)) && 
-      Objects.equal(this.getCompilationStrategy(it), null)) && 
-      Objects.equal(this.getCompilationTemplate(it), null)) && 
+      (this._iLogicalContainerProvider.getAssociatedExpression(it) == null)) && 
+      (this.getCompilationStrategy(it) == null)) && 
+      (this.getCompilationTemplate(it) == null)) && 
       (IterableExtensions.size(Iterables.<JvmConstructor>filter(it.getDeclaringType().getMembers(), JvmConstructor.class)) == 1));
   }
   
@@ -102,8 +101,7 @@ public class JvmTypeExtensions {
     EList<Adapter> _eAdapters = element.eAdapters();
     Adapter _adapter = EcoreUtil.getAdapter(_eAdapters, JvmIdentifiableMetaData.class);
     JvmIdentifiableMetaData metaData = ((JvmIdentifiableMetaData) _adapter);
-    boolean _equals = Objects.equal(metaData, null);
-    if (_equals) {
+    if ((metaData == null)) {
       JvmIdentifiableMetaData _jvmIdentifiableMetaData = new JvmIdentifiableMetaData();
       metaData = _jvmIdentifiableMetaData;
       EList<Adapter> _eAdapters_1 = element.eAdapters();

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageFacade.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageFacade.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.resource;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -57,8 +56,7 @@ public class BatchLinkableResourceStorageFacade extends ResourceStorageFacade {
         _findSourceFolderContaining=project.findSourceFolderContaining(uri);
       }
       final ISourceFolder sourceFolder = _findSourceFolderContaining;
-      boolean _notEquals = (!Objects.equal(sourceFolder, null));
-      if (_notEquals) {
+      if ((sourceFolder != null)) {
         return sourceFolder.getPath();
       }
     }

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageWritable.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageWritable.java
@@ -104,8 +104,7 @@ public class BatchLinkableResourceStorageWritable extends ResourceStorageWritabl
     } else {
       out.writeBoolean(false);
     }
-    boolean _notEquals_1 = (!Objects.equal(metaDataAdapter, null));
-    if (_notEquals_1) {
+    if ((metaDataAdapter != null)) {
       out.writeBoolean(true);
       boolean _isSynthetic = metaDataAdapter.isSynthetic();
       out.writeBoolean(_isSynthetic);
@@ -232,7 +231,7 @@ public class BatchLinkableResourceStorageWritable extends ResourceStorageWritabl
   protected String getFragment(final EObject obj) {
     String _xblockexpression = null;
     {
-      if (((Objects.equal(obj, null) || obj.eIsProxy()) || Objects.equal(obj.eResource(), null))) {
+      if (((Objects.equal(obj, null) || obj.eIsProxy()) || (obj.eResource() == null))) {
         return "none";
       }
       Resource _eResource = obj.eResource();

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/JvmElementAtOffsetHelper.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/JvmElementAtOffsetHelper.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.resource;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Set;
 import org.eclipse.emf.ecore.EObject;
@@ -30,8 +29,7 @@ public class JvmElementAtOffsetHelper {
   
   public JvmIdentifiableElement getJvmIdentifiableElement(final XtextResource resource, final int offset) {
     final EObject selectedElement = this.eObjectAtOffsetHelper.resolveElementAt(resource, offset);
-    boolean _equals = Objects.equal(selectedElement, null);
-    if (_equals) {
+    if ((selectedElement == null)) {
       return null;
     }
     if ((selectedElement instanceof JvmIdentifiableElement)) {

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/typesystem/references/IndexingLightweightTypeReferenceFactory.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/typesystem/references/IndexingLightweightTypeReferenceFactory.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.typesystem.references;
 
-import com.google.common.base.Objects;
 import java.util.Arrays;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
@@ -61,8 +60,7 @@ public class IndexingLightweightTypeReferenceFactory extends LightweightTypeRefe
     JvmArrayType _xblockexpression = null;
     {
       final JvmTypeReference componentTypeReference = it.getComponentType();
-      boolean _equals = Objects.equal(componentTypeReference, null);
-      if (_equals) {
+      if ((componentTypeReference == null)) {
         return null;
       }
       JvmArrayType _switchResult = null;
@@ -106,13 +104,11 @@ public class IndexingLightweightTypeReferenceFactory extends LightweightTypeRefe
   
   public boolean isProcedure(final XFunctionTypeRefImplCustom it) {
     final JvmTypeReference returnType = it.getReturnType();
-    boolean _equals = Objects.equal(returnType, null);
-    if (_equals) {
+    if ((returnType == null)) {
       return true;
     }
     final JvmType type = this.getType(returnType);
-    boolean _equals_1 = Objects.equal(type, null);
-    if (_equals_1) {
+    if ((type == null)) {
       return false;
     }
     boolean _eIsProxy = type.eIsProxy();
@@ -170,8 +166,8 @@ public class IndexingLightweightTypeReferenceFactory extends LightweightTypeRefe
       }
     }
     JvmTypeReference _returnType = reference.getReturnType();
-    boolean _notEquals = (!Objects.equal(_returnType, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_returnType != null);
+    if (_tripleNotEquals) {
       JvmTypeReference _returnType_1 = reference.getReturnType();
       JvmTypeReference _wrapIfNecessary = this.wrapIfNecessary(_returnType_1);
       final LightweightTypeReference returnType = this.visit(_wrapIfNecessary);
@@ -193,8 +189,7 @@ public class IndexingLightweightTypeReferenceFactory extends LightweightTypeRefe
   public JvmTypeReference wrapIfNecessary(final JvmTypeReference reference) {
     JvmTypeReference _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(reference, null);
-      if (_equals) {
+      if ((reference == null)) {
         return null;
       }
       final JvmType type = this.getType(reference);

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/typesystem/references/LightweightBoundTypeArgument.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/typesystem/references/LightweightBoundTypeArgument.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.typesystem.references;
 
-import com.google.common.base.Objects;
 import org.eclipse.xtend.lib.annotations.Data;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -36,7 +35,7 @@ public class LightweightBoundTypeArgument {
   
   public boolean isValidVariancePair() {
     VarianceInfo _mergeDeclaredWithActual = this.declaredVariance.mergeDeclaredWithActual(this.actualVariance);
-    return (!Objects.equal(_mergeDeclaredWithActual, null));
+    return (_mergeDeclaredWithActual != null);
   }
   
   public LightweightBoundTypeArgument(final LightweightTypeReference typeReference, final BoundTypeArgumentSource source, final Object origin, final VarianceInfo declaredVariance, final VarianceInfo actualVariance) {

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/typesystem/references/LightweightTypeReferenceSerializer.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/typesystem/references/LightweightTypeReferenceSerializer.java
@@ -57,8 +57,8 @@ public class LightweightTypeReferenceSerializer extends TypeReferenceVisitor {
       this.appendCommaSeparated(_parameterTypes);
       this.appender.append(")=>");
       LightweightTypeReference _returnType = reference.getReturnType();
-      boolean _equals = Objects.equal(_returnType, null);
-      if (_equals) {
+      boolean _tripleEquals = (_returnType == null);
+      if (_tripleEquals) {
         this.appender.append("void");
       } else {
         LightweightTypeReference _returnType_1 = reference.getReturnType();
@@ -92,8 +92,8 @@ public class LightweightTypeReferenceSerializer extends TypeReferenceVisitor {
       this.appendCommaSeparated(_parameterTypes);
       this.appender.append(")=>");
       LightweightTypeReference _returnType = reference.getReturnType();
-      boolean _equals = Objects.equal(_returnType, null);
-      if (_equals) {
+      boolean _tripleEquals = (_returnType == null);
+      if (_tripleEquals) {
         this.appender.append("void");
       } else {
         LightweightTypeReference _returnType_1 = reference.getReturnType();
@@ -158,8 +158,8 @@ public class LightweightTypeReferenceSerializer extends TypeReferenceVisitor {
   protected void doVisitWildcardTypeReference(final WildcardTypeReference reference) {
     this.appender.append("?");
     LightweightTypeReference _lowerBound = reference.getLowerBound();
-    boolean _notEquals = (!Objects.equal(_lowerBound, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_lowerBound != null);
+    if (_tripleNotEquals) {
       this.appender.append(" super ");
       LightweightTypeReference _lowerBound_1 = reference.getLowerBound();
       _lowerBound_1.accept(this);

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/typesystem/util/ConstraintVisitingInfo.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/typesystem/util/ConstraintVisitingInfo.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.typesystem.util;
 
-import com.google.common.base.Objects;
 import java.util.HashSet;
 import java.util.Set;
 import org.eclipse.xtext.common.types.JvmTypeParameter;
@@ -50,8 +49,7 @@ public class ConstraintVisitingInfo {
   }
   
   public void pushInfo(final JvmTypeParameterDeclarator declarator, final int idx) {
-    boolean _equals = Objects.equal(declarator, null);
-    if (_equals) {
+    if ((declarator == null)) {
       throw new NullPointerException("declarator may not be null");
     }
     this.declarator = declarator;

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/util/XSwitchExpressions.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/util/XSwitchExpressions.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.util;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.xtext.common.types.JvmFormalParameter;
@@ -43,8 +42,7 @@ public class XSwitchExpressions {
     boolean _xblockexpression = false;
     {
       final LightweightTypeReference switchType = this.getSwitchVariableType(it);
-      boolean _equals = Objects.equal(switchType, null);
-      if (_equals) {
+      if ((switchType == null)) {
         return false;
       }
       boolean _isSubtypeOf = switchType.isSubtypeOf(Integer.TYPE);
@@ -67,8 +65,7 @@ public class XSwitchExpressions {
     boolean _xblockexpression = false;
     {
       final LightweightTypeReference switchType = this.getSwitchVariableType(it);
-      boolean _equals = Objects.equal(switchType, null);
-      if (_equals) {
+      if ((switchType == null)) {
         return false;
       }
       boolean _isSubtypeOf = switchType.isSubtypeOf(Integer.TYPE);
@@ -92,20 +89,18 @@ public class XSwitchExpressions {
     boolean _xblockexpression = false;
     {
       JvmTypeReference _typeGuard = casePart.getTypeGuard();
-      boolean _notEquals = (!Objects.equal(_typeGuard, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_typeGuard != null);
+      if (_tripleNotEquals) {
         return false;
       }
       final XExpression case_ = casePart.getCase();
-      boolean _equals = Objects.equal(case_, null);
-      if (_equals) {
+      if ((case_ == null)) {
         return false;
       }
       @Extension
       final IResolvedTypes resolvedTypes = this._iBatchTypeResolver.resolveTypes(it);
       final LightweightTypeReference caseType = resolvedTypes.getActualType(case_);
-      boolean _equals_1 = Objects.equal(caseType, null);
-      if (_equals_1) {
+      if ((caseType == null)) {
         return false;
       }
       final LightweightTypeReference switchType = this.getSwitchVariableType(it);
@@ -123,8 +118,7 @@ public class XSwitchExpressions {
     @Extension
     final IResolvedTypes resolvedTypes = this._iBatchTypeResolver.resolveTypes(it);
     final JvmFormalParameter declaredParam = it.getDeclaredParam();
-    boolean _equals = Objects.equal(declaredParam, null);
-    if (_equals) {
+    if ((declaredParam == null)) {
       XExpression _switch = it.getSwitch();
       return resolvedTypes.getActualType(_switch);
     }
@@ -142,8 +136,7 @@ public class XSwitchExpressions {
   
   public boolean isConstant(final XCasePart casePart) {
     final XExpression case_ = casePart.getCase();
-    boolean _equals = Objects.equal(case_, null);
-    if (_equals) {
+    if ((case_ == null)) {
       return false;
     }
     try {
@@ -161,8 +154,7 @@ public class XSwitchExpressions {
   
   public XExpression getThen(final XCasePart casePart, final XSwitchExpression switchExpression) {
     final XExpression then = casePart.getThen();
-    boolean _notEquals = (!Objects.equal(then, null));
-    if (_notEquals) {
+    if ((then != null)) {
       return then;
     }
     EList<XCasePart> _cases = switchExpression.getCases();

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/validation/ConstantExpressionValidator.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/validation/ConstantExpressionValidator.java
@@ -119,8 +119,7 @@ public class ConstantExpressionValidator {
       if (feature instanceof JvmOperation) {
         _matched=true;
         final JvmAnnotationReference annotationReference = this._xExpressionHelper.findInlineAnnotation(expression);
-        boolean _equals = Objects.equal(annotationReference, null);
-        if (_equals) {
+        if ((annotationReference == null)) {
           return false;
         }
         EList<JvmAnnotationValue> _values = annotationReference.getValues();
@@ -132,8 +131,8 @@ public class ConstantExpressionValidator {
         if (_exists) {
           boolean _xifexpression = false;
           XExpression _actualReceiver = expression.getActualReceiver();
-          boolean _equals_1 = Objects.equal(_actualReceiver, null);
-          if (_equals_1) {
+          boolean _tripleEquals = (_actualReceiver == null);
+          if (_tripleEquals) {
             _xifexpression = true;
           } else {
             XExpression _actualReceiver_1 = expression.getActualReceiver();

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/validation/UniqueClassNameValidator.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/validation/UniqueClassNameValidator.java
@@ -75,13 +75,13 @@ public class UniqueClassNameValidator extends AbstractDeclarativeValidator {
   @Check
   public void checkUniqueName(final EObject root) {
     EObject _eContainer = root.eContainer();
-    boolean _equals = Objects.equal(_eContainer, null);
-    if (_equals) {
+    boolean _tripleEquals = (_eContainer == null);
+    if (_tripleEquals) {
       final Resource resource = root.eResource();
       EList<EObject> _contents = resource.getContents();
       EObject _head = IterableExtensions.<EObject>head(_contents);
-      boolean _equals_1 = Objects.equal(_head, root);
-      if (_equals_1) {
+      boolean _equals = Objects.equal(_head, root);
+      if (_equals) {
         EList<EObject> _contents_1 = resource.getContents();
         Iterable<JvmDeclaredType> _filter = Iterables.<JvmDeclaredType>filter(_contents_1, JvmDeclaredType.class);
         final Consumer<JvmDeclaredType> _function = (JvmDeclaredType it) -> {
@@ -94,11 +94,10 @@ public class UniqueClassNameValidator extends AbstractDeclarativeValidator {
   
   protected void doCheckUniqueName(final JvmDeclaredType type) {
     EObject _eContainer = type.eContainer();
-    boolean _equals = Objects.equal(_eContainer, null);
-    if (_equals) {
+    boolean _tripleEquals = (_eContainer == null);
+    if (_tripleEquals) {
       final QualifiedName name = this.qualifiedNameProvider.getFullyQualifiedName(type);
-      boolean _notEquals = (!Objects.equal(name, null));
-      if (_notEquals) {
+      if ((name != null)) {
         this.doCheckUniqueName(name, type);
       }
     }
@@ -137,8 +136,7 @@ public class UniqueClassNameValidator extends AbstractDeclarativeValidator {
   
   protected void addIssue(final JvmDeclaredType type, final String fileName) {
     final EObject sourceElement = this.associations.getPrimarySourceElement(type);
-    boolean _equals = Objects.equal(sourceElement, null);
-    if (_equals) {
+    if ((sourceElement == null)) {
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("The type ");
       String _simpleName = type.getSimpleName();

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xtype/util/XFunctionTypeRefs.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xtype/util/XFunctionTypeRefs.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtype.util;
 
-import com.google.common.base.Objects;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.InternalEObject;
@@ -75,8 +74,7 @@ public class XFunctionTypeRefs {
       {
         final JvmType wrappedType = XFunctionTypeRefs.getWrappedType(type);
         JvmTypeReference _xifexpression = null;
-        boolean _equals = Objects.equal(wrappedType, null);
-        if (_equals) {
+        if ((wrappedType == null)) {
           _xifexpression = reference;
         } else {
           JvmParameterizedTypeReference _createJvmParameterizedTypeReference = TypesFactory.eINSTANCE.createJvmParameterizedTypeReference();


### PR DESCRIPTION
For comparison with null the triple (not) equal operator should be used.
Resolved compiler warnings
