### PR TITLE
Fixed bug in early-exit validation

### DIFF
--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/ReturnTypeTests.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/ReturnTypeTests.xtend
@@ -151,6 +151,33 @@ abstract class AbstractReturnTypeTest<Reference> extends AbstractTypeResolverTes
 		"{ while(null instanceof String) return '' return '' }".resolvesTo("String")
 	}
 	
+	@Test def void testWhileExpression_EarlyExitWithSwitchCase() throws Exception {
+		'while(true) {
+			switch "test" {
+				case "foo" : return "result"
+			}
+		}'.resolvesTo("String")
+	}
+	
+	@Test def void testWhileExpression_EarlyExitWithSwitchDefault() throws Exception {
+		'while(true) {
+			switch "test" {
+				case "foo" : {}
+				default : return "result"
+			}
+		}'.resolvesTo("String")
+	}
+	
+	@Test def void testWhileExpression_EarlyExitWithSwitchAndIf() throws Exception {
+		'while(true) {
+			if(false) {
+				switch "test" {
+					case "foo" : if(false) return "result"
+				}
+			}
+		}'.resolvesTo("String")
+	}
+	
 	@Test override testTryCatchFinallyExpression_08() throws Exception {
 		"try return 'foo' catch (Exception e) return 'bar'".resolvesTo("String") 
 	}

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/AbstractReturnTypeTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/AbstractReturnTypeTest.java
@@ -188,6 +188,21 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
   }
   
   @Test
+  public void testWhileExpression_EarlyExitWithSwitchCase() throws Exception {
+    this.resolvesTo("while(true) {\n\t\t\tswitch \"test\" {\n\t\t\t\tcase \"foo\" : return \"result\"\n\t\t\t}\n\t\t}", "String");
+  }
+  
+  @Test
+  public void testWhileExpression_EarlyExitWithSwitchDefault() throws Exception {
+    this.resolvesTo("while(true) {\n\t\t\tswitch \"test\" {\n\t\t\t\tcase \"foo\" : {}\n\t\t\t\tdefault : return \"result\"\n\t\t\t}\n\t\t}", "String");
+  }
+  
+  @Test
+  public void testWhileExpression_EarlyExitWithSwitchAndIf() throws Exception {
+    this.resolvesTo("while(true) {\n\t\t\tif(false) {\n\t\t\t\tswitch \"test\" {\n\t\t\t\t\tcase \"foo\" : if(false) return \"result\"\n\t\t\t\t}\n\t\t\t}\n\t\t}", "String");
+  }
+  
+  @Test
   @Override
   public void testTryCatchFinallyExpression_08() throws Exception {
     this.resolvesTo("try return \'foo\' catch (Exception e) return \'bar\'", "String");

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/ExtendedEarlyExitComputer.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/ExtendedEarlyExitComputer.java
@@ -65,7 +65,18 @@ public class ExtendedEarlyExitComputer {
 				}
 			}
 		} else if (expression instanceof XIfExpression) {
-			return isIntentionalEarlyExit(((XIfExpression) expression).getThen()) && isIntentionalEarlyExit(((XIfExpression) expression).getElse());
+			return isIntentionalEarlyExit(((XIfExpression) expression).getThen()) 
+					|| isIntentionalEarlyExit(((XIfExpression) expression).getElse());
+		} else if (expression instanceof XSwitchExpression) {
+			XSwitchExpression switchExpression = (XSwitchExpression) expression;
+			for(XCasePart caseExpression: switchExpression.getCases()) {
+				if (isIntentionalEarlyExit(caseExpression.getThen())) {
+					return true;
+				}
+			}
+			if (isIntentionalEarlyExit(switchExpression.getDefault())) {
+				return true;
+			}
 		} else if (expression instanceof XTryCatchFinallyExpression) {
 			XTryCatchFinallyExpression tryCatchFinally = (XTryCatchFinallyExpression) expression;
 			if (isIntentionalEarlyExit(tryCatchFinally.getExpression())) {


### PR DESCRIPTION
Added support for switch expressions to the early-exit computer.

currently this works:
`def String foo() {
	while(true) {
		if(false) return "test"
	}
}`

but this fails:
`def String bar() {
	while(true) {
		switch false {
			case true: return "test" 
		}
	}
}`

with the message "Type mismatch: cannot convert from void to String", this PR fixes this problem

Signed-off-by: Lieven Lemiengre <lieven.lemiengre@sigasi.com>