### PR TITLE
[xbase.testing + releng/releng-target] consolidated version of 'org.junit' dependency

### DIFF
--- a/gradle/p2-deployment.gradle
+++ b/gradle/p2-deployment.gradle
@@ -20,4 +20,9 @@ p2gen {
 	dependencies {
 		repositoryUrl 'http://download.eclipse.org/releases/luna/201502271000/'
 	}
+	dependencies {
+		repositoryUrl 'http://download.eclipse.org/modeling/tmf/xtext/updates/orbit/'
+		bundle 'org.junit'
+		includeSource true
+	}
 }

--- a/org.eclipse.xtext.xbase.testing/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.testing/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase,
  org.eclipse.jdt.core;bundle-version="3.6.0",
- org.junit;bundle-version="4.11.0"
+ org.junit;bundle-version="4.12.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.xtext.xbase.testing
 Import-Package: org.apache.log4j;version="1.2.15"

--- a/releng/releng-target/xtext-extras.target.target
+++ b/releng/releng-target/xtext-extras.target.target
@@ -9,5 +9,9 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="http://download.eclipse.org/releases/luna/201502271000/"/>
 		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/orbit/"/>
+			<unit id="org.junit" version="0.0.0"/>
+		</location>
 	</locations>
 </target>


### PR DESCRIPTION
This PR is in line with https://github.com/eclipse/xtext-core/pull/208 and synchronizes `org.eclipse.xtext.xbase.testing`s manifest dependency to `org.junit` with the gradle config.
To that end I had to include `org.junit` from the orbit update site (proxy).

Signed-off-by: Christian Schneider <christian.schneider@typefox.io>