### PR TITLE
Improve Xtend bootstrap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,9 @@ subprojects {
 	version = rootProject.version
 	
 	apply plugin: 'java'
-	apply plugin: 'org.xtext.xtend'
+	if (findProperty('skipXtendCompiler') != 'true') {
+		apply plugin: 'org.xtext.xtend'
+	}
 	apply plugin: 'eclipse'
 	apply plugin: 'maven'
 	

--- a/gradle/bootstrap-setup.gradle
+++ b/gradle/bootstrap-setup.gradle
@@ -5,7 +5,10 @@
 // The repositories to query when constructing the Xtend compiler classpath
 repositories {
 	jcenter()
-	maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+	maven {
+		name 'xtend-bootstrap'
+		url 'http://services.typefox.io/open-source/jenkins/job/xtend-bootstrap/lastStableBuild/artifact/build-result/maven-repository/'
+	}
 }
 
 // The Xtend compiler version to use

--- a/gradle/eclipse-project-layout.gradle
+++ b/gradle/eclipse-project-layout.gradle
@@ -16,7 +16,11 @@ sourceSets {
 			srcDirs = sourceDirs
 			exclude '**/*.java', '**/*.xtend'
 		}
-		xtendOutputDir = 'xtend-gen'
+		if (findProperty('skipXtendCompiler') == 'true') {
+			java.srcDir 'xtend-gen'
+		} else {
+			xtendOutputDir = 'xtend-gen'
+		}
 	}
 	configure(isTestProject? main : test) {
 		java.srcDirs = []

--- a/gradle/xtend-compiler-settings.gradle
+++ b/gradle/xtend-compiler-settings.gradle
@@ -2,17 +2,19 @@
  * Configuration of Xtend compiler.
  */
 
-[generateXtext, generateTestXtext].each { gen ->
-	gen.xtextClasspath = rootProject.configurations.getByName('xtendCompiler')
-}
-
-sourcesJar {
-	from (sourceSets.main.xtendOutputDir) {
-		include '**/*._trace'
+if (findProperty('skipXtendCompiler') != 'true') {
+	[generateXtext, generateTestXtext].each { gen ->
+		gen.xtextClasspath = rootProject.configurations.getByName('xtendCompiler')
 	}
-	if (name.endsWith('tests')) {
-		from (sourceSets.test.xtendOutputDir) {
+	
+	sourcesJar {
+		from (sourceSets.main.xtendOutputDir) {
 			include '**/*._trace'
+		}
+		if (name.endsWith('tests')) {
+			from (sourceSets.test.xtendOutputDir) {
+				include '**/*._trace'
+			}
 		}
 	}
 }

--- a/org.eclipse.xtext.xbase.tests/build.gradle
+++ b/org.eclipse.xtext.xbase.tests/build.gradle
@@ -13,7 +13,11 @@ dependencies {
 sourceSets {
 	longrunning {
 		java.srcDirs = ['longrunning/src']
-		xtendOutputDir = 'longrunning/xtend-gen'
+		if (findProperty('skipXtendCompiler') == 'true') {
+			java.srcDir 'longrunning/xtend-gen'
+		} else {
+			xtendOutputDir = 'longrunning/xtend-gen'
+		}
 		compileClasspath += sourceSets.test.output
 		runtimeClasspath += sourceSets.test.output
 	}
@@ -31,7 +35,9 @@ configurations {
 	suitesRuntime.extendsFrom testRuntime
 }
 
-generateLongrunningXtext.xtextClasspath = rootProject.configurations.getByName('xtendCompiler')
+if (findProperty('skipXtendCompiler') != 'true') {
+	generateLongrunningXtext.xtextClasspath = rootProject.configurations.getByName('xtendCompiler')
+}
 
 jar {
 	from (sourceSets.longrunning.output)


### PR DESCRIPTION
* Use build result from xtend-bootstrap job for Xtend compiler
* Added `skipXtendCompiler` option