### PR TITLE
added explicit dependencies to jdtCompilerApt.

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -13,6 +13,7 @@ ext.versions = [
 	'emfMwe': '1.3.20.201605261059',
 	'emfMwe2': '2.9.0.201605261059',
 	'jdtCore': '3.12.2',
+	'jdtCompilerApt': '1.2.100',
 	'xpand': '2.0.0',
 	'asm': '5.0.1',
 	'icu': '52.1',

--- a/org.eclipse.xtext.builder.standalone.tests/build.gradle
+++ b/org.eclipse.xtext.builder.standalone.tests/build.gradle
@@ -2,7 +2,6 @@ dependencies {
 	compile project(':org.eclipse.xtext.builder.standalone')
 	compile project(':org.eclipse.xtext.ecore')
 	compile "org.eclipse.xtext:org.eclipse.xtext.testing:$versions.xtext"
-	compile "org.eclipse.jdt:org.eclipse.jdt.core:$versions.jdtCore"
 	compile "junit:junit:$versions.junit"
 	mwe2Compile project(':org.eclipse.xtext.generator')
 	mwe2Runtime "org.eclipse.emf:org.eclipse.emf.mwe2.launch:$versions.emfMwe2"

--- a/org.eclipse.xtext.builder.standalone/build.gradle
+++ b/org.eclipse.xtext.builder.standalone/build.gradle
@@ -5,4 +5,5 @@ dependencies {
 	compile project(':org.eclipse.xtext.xbase')
 	compile project(':org.eclipse.xtext.common.types')
 	compile "org.eclipse.jdt:org.eclipse.jdt.core:$versions.jdtCore"
+	compile "org.eclipse.jdt:org.eclipse.jdt.compiler.apt:$versions.jdtCompilerApt"
 }

--- a/org.eclipse.xtext.common.types.tests/build.gradle
+++ b/org.eclipse.xtext.common.types.tests/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compile project(':org.eclipse.xtext.common.types')
 	compile project(':org.eclipse.xtext.xbase.testdata')
 	compile "org.eclipse.jdt:org.eclipse.jdt.core:$versions.jdtCore"
+	compile "org.eclipse.jdt:org.eclipse.jdt.compiler.apt:$versions.jdtCompilerApt"
 	compile "org.eclipse.xtext:org.eclipse.xtext.testing:$versions.xtext"
 	compile "org.eclipse.xtext:org.eclipse.xtext.testlanguages:$versions.xtext"
 	compile "junit:junit:$versions.junit"

--- a/org.eclipse.xtext.generator/build.gradle
+++ b/org.eclipse.xtext.generator/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compile "org.eclipse.xpand:org.eclipse.xpand:$versions.xpand"
 	compile "org.eclipse.xpand:org.eclipse.xtend:$versions.xpand"
 	optional "org.eclipse.jdt:org.eclipse.jdt.core:$versions.jdtCore"
+	optional "org.eclipse.jdt:org.eclipse.jdt.compiler.apt:$versions.jdtCompilerApt"
 }
 
 sourceSets.main.java.srcDir 'packrat'

--- a/org.eclipse.xtext.java/build.gradle
+++ b/org.eclipse.xtext.java/build.gradle
@@ -4,4 +4,5 @@ description = 'Integrate Xtext languages with Java code.'
 dependencies {
 	compile project(':org.eclipse.xtext.common.types')
 	compile "org.eclipse.jdt:org.eclipse.jdt.core:$versions.jdtCore"
+	compile "org.eclipse.jdt:org.eclipse.jdt.compiler.apt:$versions.jdtCompilerApt"
 }

--- a/org.eclipse.xtext.purexbase.tests/build.gradle
+++ b/org.eclipse.xtext.purexbase.tests/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compile project(':org.eclipse.xtext.xbase.testing')
 	compile project(':org.eclipse.xtext.xbase.testdata')
 	compile "org.eclipse.jdt:org.eclipse.jdt.core:$versions.jdtCore"
+	compile "org.eclipse.jdt:org.eclipse.jdt.compiler.apt:$versions.jdtCompilerApt"
 	compile "org.eclipse.xtext:org.eclipse.xtext.testing:$versions.xtext"
 	compile "junit:junit:$versions.junit"
 }

--- a/org.eclipse.xtext.xbase.testing/build.gradle
+++ b/org.eclipse.xtext.xbase.testing/build.gradle
@@ -5,4 +5,5 @@ dependencies {
 	compile project(':org.eclipse.xtext.xbase')
 	compile "junit:junit:$versions.junit"
 	compile "org.eclipse.jdt:org.eclipse.jdt.core:$versions.jdtCore"
+	compile "org.eclipse.jdt:org.eclipse.jdt.compiler.apt:$versions.jdtCompilerApt"
 }

--- a/org.eclipse.xtext.xbase.tests/build.gradle
+++ b/org.eclipse.xtext.xbase.tests/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compile project(':org.eclipse.xtext.xbase.testdata')
 
 	compile "org.eclipse.jdt:org.eclipse.jdt.core:$versions.jdtCore"
+	compile "org.eclipse.jdt:org.eclipse.jdt.compiler.apt:$versions.jdtCompilerApt"
 	compile "org.eclipse.xtext:org.eclipse.xtext.testing:$versions.xtext"
 	compile "junit:junit:$versions.junit"
 }


### PR DESCRIPTION
added explicit dependencies to jdtCompilerApt.
fixes https://github.com/eclipse/xtext-maven/issues/9

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>