### PR TITLE
[460455] Avoid import of inner classes

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/ImportOrganizer.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/ImportOrganizer.java
@@ -202,7 +202,10 @@ public class ImportOrganizer {
 			String name) {
 		for (TypeUsage usage : usages) {
 			JvmIdentifiableElement visibleType = nonOverridableTypesProvider.getVisibleType(usage.getContext(), name);
-			if (visibleType == null && (!equal(usage.getContextPackageName(), type.getPackageName()) || type.getDeclaringType() != null))
+			if (visibleType == null && (
+				!equal(usage.getContextPackageName(), type.getPackageName())
+				|| (type.getDeclaringType() != null && usage.getContext().eResource() != type.getDeclaringType().eResource())
+			))
 				return false;
 		}
 		return true;


### PR DESCRIPTION
A usage is local when the declared type is withing the same resource as
the usage context

Fixes the first issue described in https://bugs.eclipse.org/bugs/show_bug.cgi?id=460455