### PR TITLE
fixed compilation of BigInteger Literals of type 1.23e45

### DIFF
--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/compiler/CompilerTests2.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/compiler/CompilerTests2.xtend
@@ -2125,4 +2125,36 @@ class CompilerTests2 extends AbstractOutputComparingCompilerTests {
 			return ("Foo" != null);
 		''')
 	}
+
+	@Test def void testBigIntegerLiteral01 () {
+		'''
+			1bi
+		'''.compilesTo ('''
+			return java.math.BigInteger.ONE;
+		''')
+	}
+
+	@Test def void testBigIntegerLiteral02 () {
+		'''
+			1.0bi
+		'''.compilesTo ('''
+			return java.math.BigInteger.ONE;
+		''')
+	}
+
+	@Test def void testBigIntegerLiteral03 () {
+		'''
+			1e23bi
+		'''.compilesTo ('''
+			return new java.math.BigInteger("1").multiply(java.math.BigInteger.TEN.pow(23));
+		''')
+	}
+
+	@Test def void testBigIntegerLiteral04 () {
+		'''
+			1.23e45bi
+		'''.compilesTo ('''
+			return new java.math.BigDecimal("1.23").multiply(java.math.BigDecimal.TEN.pow(45)).toBigInteger();
+		''')
+	}
 }

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/compiler/CompilerTests2.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/compiler/CompilerTests2.java
@@ -4571,4 +4571,64 @@ public class CompilerTests2 extends AbstractOutputComparingCompilerTests {
       throw Exceptions.sneakyThrow(_e);
     }
   }
+  
+  @Test
+  public void testBigIntegerLiteral01() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("1bi");
+      _builder.newLine();
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("return java.math.BigInteger.ONE;");
+      _builder_1.newLine();
+      this.compilesTo(_builder, _builder_1);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testBigIntegerLiteral02() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("1.0bi");
+      _builder.newLine();
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("return java.math.BigInteger.ONE;");
+      _builder_1.newLine();
+      this.compilesTo(_builder, _builder_1);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testBigIntegerLiteral03() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("1e23bi");
+      _builder.newLine();
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("return new java.math.BigInteger(\"1\").multiply(java.math.BigInteger.TEN.pow(23));");
+      _builder_1.newLine();
+      this.compilesTo(_builder, _builder_1);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testBigIntegerLiteral04() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("1.23e45bi");
+      _builder.newLine();
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("return new java.math.BigDecimal(\"1.23\").multiply(java.math.BigDecimal.TEN.pow(45)).toBigInteger();");
+      _builder_1.newLine();
+      this.compilesTo(_builder, _builder_1);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
 }

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/LiteralsCompiler.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/LiteralsCompiler.java
@@ -159,10 +159,19 @@ public class LiteralsCompiler extends TypeConvertingCompiler {
 							digits = digits.substring(0, e);
 						}
 					}
-					b.append("new ").append(type.getType()).append("(\"")
+					final boolean fracturedDigits = digits.contains(".");
+					if (fracturedDigits) {
+						b.append("new ").append(BigDecimal.class).append("(\"")
 						.append(digits).append("\"");
-					if (base != 10) {
-						b.append(", ").append(Integer.toString(base));
+						if (base != 10) {
+							b.append(", ").append(Integer.toString(base));
+						}
+					} else {
+						b.append("new ").append(type.getType()).append("(\"")
+						.append(digits).append("\"");
+						if (base != 10) {
+							b.append(", ").append(Integer.toString(base));
+						}
 					}
 					b.append(")");
 					if (exponent != null) {
@@ -173,7 +182,11 @@ public class LiteralsCompiler extends TypeConvertingCompiler {
 						} else {
 							exponentAsString = Integer.toString(exponentAsInt);
 						}
-						b.append(".multiply(").append(type.getType()).append(".TEN.pow(").append(exponentAsString).append("))");
+						if (fracturedDigits) {
+							b.append(".multiply(").append(BigDecimal.class).append(".TEN.pow(").append(exponentAsString).append(")).toBigInteger()");
+						} else {
+							b.append(".multiply(").append(type.getType()).append(".TEN.pow(").append(exponentAsString).append("))");
+						}
 					}
 				}
 			}


### PR DESCRIPTION
fixed compilation of BigInteger Literals of type 1.23e45 to avoid runtime error. fixes #40

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>