### PR TITLE
findMember: do a full name match first and then the startsWith match

### DIFF
--- a/org.eclipse.xtext.common.types/src/org/eclipse/xtext/common/types/access/impl/AbstractClassMirror.java
+++ b/org.eclipse.xtext.common.types/src/org/eclipse/xtext/common/types/access/impl/AbstractClassMirror.java
@@ -126,6 +126,9 @@ public abstract class AbstractClassMirror implements IClassMirror {
 				if(equal(fragment,name)) {
 					return member;
 				}
+			}
+			for(JvmMember member: members) {
+				String name = member.getIdentifier();
 				if(fragment.startsWith(name)) {
 					EObject match = findMember(member, fragment);
 					if(match != null) 


### PR DESCRIPTION
findMember: do a full name match first and then the startsWith match. fixes #114

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>