### PR TITLE
[426073] [xtend][compiler] The generated Java code contains a conflict between a field name and an imported class name

### DIFF
--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/compiler/JvmModelGeneratorTest.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/compiler/JvmModelGeneratorTest.xtend
@@ -35,6 +35,7 @@ import org.eclipse.xtext.xbase.tests.typesystem.XbaseWithLogicalContainerInjecto
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.eclipse.emf.common.util.URI
 
 @RunWith(typeof(XtextRunner))
 @InjectWith(typeof(XbaseWithLogicalContainerInjectorProvider))
@@ -539,7 +540,17 @@ class JvmModelGeneratorTest extends AbstractXbaseTestCase {
 		assertTrue(Modifier::isStrict(compiled.getMethod("strictFpMethod").modifiers))
 		assertTrue(Modifier::isNative(compiled.getMethod("nativeMethod").modifiers))
 	}
-
+	
+	@Test def void testBug426073() {
+		val expression = expression("org.eclipse.emf.common.util.URI.createURI(\"dummy\")")
+		val clazz = expression.toClass("my.test.Foo") [
+			members += expression.toField("URI", expression.typeRef(URI)) [
+				initializer = expression
+			]
+		]
+		compile(expression.eResource, clazz)
+	}
+	
 	def JvmTypeReference typeRef(EObject ctx, Class<?> clazz) {
 		return references.getTypeForName(clazz, ctx)
 	}

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/compiler/JvmModelGeneratorTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/compiler/JvmModelGeneratorTest.java
@@ -19,6 +19,7 @@ import java.util.AbstractList;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtend2.lib.StringConcatenation;
@@ -931,6 +932,25 @@ public class JvmModelGeneratorTest extends AbstractXbaseTestCase {
       Assert.assertTrue(Modifier.isSynchronized(compiled.getMethod("synchronizedMethod").getModifiers()));
       Assert.assertTrue(Modifier.isStrict(compiled.getMethod("strictFpMethod").getModifiers()));
       Assert.assertTrue(Modifier.isNative(compiled.getMethod("nativeMethod").getModifiers()));
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testBug426073() {
+    try {
+      final XExpression expression = this.expression("org.eclipse.emf.common.util.URI.createURI(\"dummy\")");
+      final Procedure1<JvmGenericType> _function = (JvmGenericType it) -> {
+        EList<JvmMember> _members = it.getMembers();
+        final Procedure1<JvmField> _function_1 = (JvmField it_1) -> {
+          this.builder.setInitializer(it_1, expression);
+        };
+        JvmField _field = this.builder.toField(expression, "URI", this.typeRef(expression, URI.class), _function_1);
+        this.builder.<JvmField>operator_add(_members, _field);
+      };
+      final JvmGenericType clazz = this.builder.toClass(expression, "my.test.Foo", _function);
+      this.compile(expression.eResource(), clazz);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.xtend
@@ -455,7 +455,8 @@ class JvmModelGenerator implements IGenerator {
 		generateModifier(tracedAppendable, config)
 		type.serializeSafely("Object", tracedAppendable)
 		tracedAppendable.append(" ")
-		tracedAppendable.traceSignificant(it).append(simpleName.makeJavaIdentifier)
+		val name = tracedAppendable.declareVariable(it, simpleName.makeJavaIdentifier)
+		tracedAppendable.traceSignificant(it).append(name)
 		generateInitialization(tracedAppendable, config)
 		tracedAppendable.append(";")
 	}

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.java
@@ -760,7 +760,8 @@ public class JvmModelGenerator implements IGenerator {
       this.generateModifier(it, tracedAppendable, config);
       this._errorSafeExtensions.serializeSafely(it.getType(), "Object", tracedAppendable);
       tracedAppendable.append(" ");
-      this._treeAppendableUtil.traceSignificant(tracedAppendable, it).append(this.makeJavaIdentifier(it.getSimpleName()));
+      final String name = tracedAppendable.declareVariable(it, this.makeJavaIdentifier(it.getSimpleName()));
+      this._treeAppendableUtil.traceSignificant(tracedAppendable, it).append(name);
       this.generateInitialization(it, tracedAppendable, config);
       _xblockexpression = tracedAppendable.append(";");
     }


### PR DESCRIPTION
[426073] [xtend][compiler] The generated Java code contains a conflict between a field name and an imported class name

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>