### PR TITLE
[515801] ClassCastException in OverrideHelper.findOverriddenOperation and AbstractResolvedOperation.getOverriddenAndImplementedMethodCandidates

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/override/AbstractResolvedOperation.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/override/AbstractResolvedOperation.java
@@ -128,12 +128,14 @@ public abstract class AbstractResolvedOperation extends AbstractResolvedExecutab
 		List<LightweightTypeReference> superTypes = currentDeclarator.getSuperTypes();
 		List<JvmOperation> result = Lists.newArrayListWithCapacity(5);
 		for(LightweightTypeReference superType: superTypes) {
-			JvmDeclaredType declaredSuperType = (JvmDeclaredType) superType.getType();
-			if (declaredSuperType != null) {
-				Iterable<JvmFeature> equallyNamedFeatures = declaredSuperType.findAllFeaturesByName(getDeclaration().getSimpleName());
-				for(JvmFeature equallyNamedFeature: equallyNamedFeatures) {
-					if (equallyNamedFeature instanceof JvmOperation) {
-						result.add((JvmOperation) equallyNamedFeature);
+			if (superType.getType() instanceof JvmDeclaredType) {
+				JvmDeclaredType declaredSuperType = (JvmDeclaredType) superType.getType();
+				if (declaredSuperType != null) {
+					Iterable<JvmFeature> equallyNamedFeatures = declaredSuperType.findAllFeaturesByName(getDeclaration().getSimpleName());
+					for(JvmFeature equallyNamedFeature: equallyNamedFeatures) {
+						if (equallyNamedFeature instanceof JvmOperation) {
+							result.add((JvmOperation) equallyNamedFeature);
+						}
 					}
 				}
 			}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/override/OverrideHelper.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/override/OverrideHelper.java
@@ -125,22 +125,24 @@ public class OverrideHelper {
 		int parameterSize = operation.getParameters().size();
 		List<LightweightTypeReference> superTypes = declaringType.getSuperTypes();
 		for(LightweightTypeReference superType: superTypes) {
-			JvmDeclaredType declaredSuperType = (JvmDeclaredType) superType.getType();
-			if (declaredSuperType != null) {
-				Iterable<JvmFeature> equallyNamedFeatures = declaredSuperType.findAllFeaturesByName(operation.getSimpleName());
-				for(JvmFeature feature: equallyNamedFeatures) {
-					if (feature instanceof JvmOperation) {
-						JvmOperation candidate = (JvmOperation) feature;
-						if (parameterSize == candidate.getParameters().size()) {
-							if (visibilityHelper.isVisible(feature)) {
-								boolean matchesSignature = true;
-								for(int i = 0; i < parameterSize && matchesSignature; i++) {
-									JvmFormalParameter parameter = operation.getParameters().get(i);
-									JvmFormalParameter candidateParameter = candidate.getParameters().get(i);
-									matchesSignature = isMatchesSignature(parameter, candidateParameter, substitutor, owner);
-								}
-								if (matchesSignature) {
-									return candidate;
+			if (superType instanceof JvmDeclaredType) {
+				JvmDeclaredType declaredSuperType = (JvmDeclaredType) superType.getType();
+				if (declaredSuperType != null) {
+					Iterable<JvmFeature> equallyNamedFeatures = declaredSuperType.findAllFeaturesByName(operation.getSimpleName());
+					for(JvmFeature feature: equallyNamedFeatures) {
+						if (feature instanceof JvmOperation) {
+							JvmOperation candidate = (JvmOperation) feature;
+							if (parameterSize == candidate.getParameters().size()) {
+								if (visibilityHelper.isVisible(feature)) {
+									boolean matchesSignature = true;
+									for(int i = 0; i < parameterSize && matchesSignature; i++) {
+										JvmFormalParameter parameter = operation.getParameters().get(i);
+										JvmFormalParameter candidateParameter = candidate.getParameters().get(i);
+										matchesSignature = isMatchesSignature(parameter, candidateParameter, substitutor, owner);
+									}
+									if (matchesSignature) {
+										return candidate;
+									}
 								}
 							}
 						}


### PR DESCRIPTION
[515801] ClassCastException in OverrideHelper.findOverriddenOperation and AbstractResolvedOperation.getOverriddenAndImplementedMethodCandidates

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>