### PR TITLE
Increased guava version to include version 21. 

### DIFF
--- a/org.eclipse.xtext.common.types/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.common.types/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle:
  org.eclipse.emf.mwe2.lib;bundle-version="2.2.0";resolution:=optional;x-installation:=greedy,
  org.objectweb.asm;bundle-version="[5.0.1,6.0.0)",
  org.eclipse.xtend.lib,
- com.google.guava;bundle-version="[14.0.0,19.0.0)"
+ com.google.guava;bundle-version="[14.0.0,22.0.0)"
 Import-Package: org.apache.commons.logging;version="1.0.4";resolution:=optional,
  org.apache.log4j;version="1.2.15"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8


### PR DESCRIPTION
Increased guava version to include version 21.
https://github.com/eclipse/xtext-lib/issues/30

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>