### PR TITLE
JvmModelAssociator removeAssociation does not remove source to jvmElement association #161

### DIFF
--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/jvmmodel/JvmModelAssociaterTest.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/jvmmodel/JvmModelAssociaterTest.xtend
@@ -67,6 +67,51 @@ class JvmModelAssociaterTest extends AbstractJvmModelTest {
 		// test extends object and default constructor
 		assertEquals(1, type.members.filter(typeof(JvmConstructor)).size)
 		assertEquals("java.lang.Object", type.superTypes.head?.qualifiedName)
-	}	
+	}
+	
+	@Test
+	def void testRemoveAssociation() {
+		assoc.inferrerProvider = [[obj, acceptor, preIndexing|
+			val firstType = obj.toClass('foo.Bar')
+			val secondType = obj.toClass('foo.Baz') 
+			assertNull(secondType.eResource)
+			acceptor.accept(firstType) [
+				^abstract = true
+				assertNotNull(firstType.eResource)
+				assertNotNull(secondType.eResource)
+			]
+			acceptor.accept(secondType) [
+				^abstract = true
+				assertNotNull(firstType.eResource)
+			]
+		]]
+		resource.setDerivedStateComputer(null)
+		resource.URI = URI::createURI('foo.txt')
+		resourceSet.classpathURIContext = getClass()
+		resourceSet.resources += resource
+		val root = EcoreFactory::eINSTANCE.createEClass
+		resource.contents += root
+		assoc.installDerivedState(resource,true)
+		var jvmElements = assoc.getJvmElements(root)
+		assertEquals(2, jvmElements.size)
+		val jvmElement1 = jvmElements.get(0)
+		val jvmElement2 = jvmElements.get(1)
+		var sources1 = assoc.getSourceElements(jvmElement1)
+		assertEquals(1, sources1.size)
+		assertEquals(root, sources1.get(0))
+		var sources2 = assoc.getSourceElements(jvmElement2)
+		assertEquals(1, sources2.size)
+		assertEquals(root, sources2.get(0))
+		// test
+		assoc.removeAssociation(root, jvmElement2)
+		
+		jvmElements = assoc.getJvmElements(root)
+		assertEquals(1, jvmElements.size)
+		sources1 = assoc.getSourceElements(jvmElement1)
+		assertEquals(1, sources1.size)
+		assertEquals(root, sources1.get(0))
+		sources2 = assoc.getSourceElements(jvmElement2)
+		assertEquals(0, sources2.size)
+	}
 }
 

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/jvmmodel/JvmModelAssociaterTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/jvmmodel/JvmModelAssociaterTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.MembersInjector;
 import com.google.inject.Provider;
+import java.util.Set;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
@@ -20,6 +21,7 @@ import org.eclipse.xtext.xbase.jvmmodel.IJvmDeclaredTypeAcceptor;
 import org.eclipse.xtext.xbase.jvmmodel.IJvmModelInferrer;
 import org.eclipse.xtext.xbase.jvmmodel.JvmModelAssociator;
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypesBuilder;
+import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
@@ -106,5 +108,61 @@ public class JvmModelAssociaterTest extends AbstractJvmModelTest {
       _qualifiedName=_head.getQualifiedName();
     }
     Assert.assertEquals("java.lang.Object", _qualifiedName);
+  }
+  
+  @Test
+  public void testRemoveAssociation() {
+    final Provider<IJvmModelInferrer> _function = () -> {
+      final IJvmModelInferrer _function_1 = (EObject obj, IJvmDeclaredTypeAcceptor acceptor, boolean preIndexing) -> {
+        final JvmGenericType firstType = this._jvmTypesBuilder.toClass(obj, "foo.Bar");
+        final JvmGenericType secondType = this._jvmTypesBuilder.toClass(obj, "foo.Baz");
+        Assert.assertNull(secondType.eResource());
+        final Procedure1<JvmGenericType> _function_2 = (JvmGenericType it) -> {
+          it.setAbstract(true);
+          Assert.assertNotNull(firstType.eResource());
+          Assert.assertNotNull(secondType.eResource());
+        };
+        acceptor.<JvmGenericType>accept(firstType, _function_2);
+        final Procedure1<JvmGenericType> _function_3 = (JvmGenericType it) -> {
+          it.setAbstract(true);
+          Assert.assertNotNull(firstType.eResource());
+        };
+        acceptor.<JvmGenericType>accept(secondType, _function_3);
+      };
+      return _function_1;
+    };
+    this.assoc.setInferrerProvider(_function);
+    this.resource.setDerivedStateComputer(null);
+    this.resource.setURI(URI.createURI("foo.txt"));
+    this.resourceSet.setClasspathURIContext(this.getClass());
+    EList<Resource> _resources = this.resourceSet.getResources();
+    this._jvmTypesBuilder.<DerivedStateAwareResource>operator_add(_resources, this.resource);
+    final EClass root = EcoreFactory.eINSTANCE.createEClass();
+    EList<EObject> _contents = this.resource.getContents();
+    this._jvmTypesBuilder.<EClass>operator_add(_contents, root);
+    this.assoc.installDerivedState(this.resource, true);
+    Set<EObject> jvmElements = this.assoc.getJvmElements(root);
+    Assert.assertEquals(2, jvmElements.size());
+    final Set<EObject> _converted_jvmElements = (Set<EObject>)jvmElements;
+    final EObject jvmElement1 = ((EObject[])Conversions.unwrapArray(_converted_jvmElements, EObject.class))[0];
+    final Set<EObject> _converted_jvmElements_1 = (Set<EObject>)jvmElements;
+    final EObject jvmElement2 = ((EObject[])Conversions.unwrapArray(_converted_jvmElements_1, EObject.class))[1];
+    Set<EObject> sources1 = this.assoc.getSourceElements(jvmElement1);
+    Assert.assertEquals(1, sources1.size());
+    final Set<EObject> _converted_sources1 = (Set<EObject>)sources1;
+    Assert.assertEquals(root, ((Object[])Conversions.unwrapArray(_converted_sources1, Object.class))[0]);
+    Set<EObject> sources2 = this.assoc.getSourceElements(jvmElement2);
+    Assert.assertEquals(1, sources2.size());
+    final Set<EObject> _converted_sources2 = (Set<EObject>)sources2;
+    Assert.assertEquals(root, ((Object[])Conversions.unwrapArray(_converted_sources2, Object.class))[0]);
+    this.assoc.removeAssociation(root, jvmElement2);
+    jvmElements = this.assoc.getJvmElements(root);
+    Assert.assertEquals(1, jvmElements.size());
+    sources1 = this.assoc.getSourceElements(jvmElement1);
+    Assert.assertEquals(1, sources1.size());
+    final Set<EObject> _converted_sources1_1 = (Set<EObject>)sources1;
+    Assert.assertEquals(root, ((Object[])Conversions.unwrapArray(_converted_sources1_1, Object.class))[0]);
+    sources2 = this.assoc.getSourceElements(jvmElement2);
+    Assert.assertEquals(0, sources2.size());
   }
 }

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/jvmmodel/JvmModelAssociator.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/jvmmodel/JvmModelAssociator.java
@@ -465,7 +465,7 @@ public class JvmModelAssociator implements IJvmModelAssociations, IJvmModelAssoc
 		Set<EObject> sources = targetToSourceMap(resource).get(jvmElement);
 		if (sources != null && sources.remove(sourceElement)) {
 			Set<EObject> targets = sourceToTargetMap(resource).get(sourceElement);
-			targets.remove(sourceElement);
+			targets.remove(jvmElement);
 		}
 	}
 


### PR DESCRIPTION
JvmModelAssociator removeAssociation does not remove source to jvmElement association #161

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>