### PR TITLE
Fixed issue in impl of InMemoryClassLoader.getResource(String)

### DIFF
--- a/org.eclipse.xtext.java.tests/src/org/eclipse/xtext/java/tests/JavaSourceLanguageTest.xtend
+++ b/org.eclipse.xtext.java.tests/src/org/eclipse/xtext/java/tests/JavaSourceLanguageTest.xtend
@@ -85,6 +85,24 @@ class JavaSourceLanguageTest {
         Assert.assertSame(annotation, annotationRef.annotation)
     }
 
+    @Test def void testClassShadowing() {
+    	    val rs = resourceSet('org/eclipse/xtext/java/tests/MySuperClass2.java' -> '''
+            package org.eclipse.xtext.java.tests;
+            public class MySuperClass2 {
+                public void doSomething() {
+                    
+                }
+            }
+        ''', 'org/eclipse/xtext/java/tests/MySubClass2.java' -> '''
+            package org.eclipse.xtext.java.tests;
+            public class MySubClass2 extends MySuperClass2 {
+            }
+        ''')
+        val superResource = rs.resources.findFirst[URI.toString.endsWith('MySuperClass2.java')]
+        val clazz = superResource.contents.head as JvmGenericType
+        Assert.assertNotNull(clazz.declaredOperations.head)
+    }
+
     @Inject Provider<XtextResourceSet> resourceSetProvider
     @Inject IResourceDescription.Manager resourceDesriptionManager
     @Inject IJvmTypeProvider.Factory typeProviderFactory

--- a/org.eclipse.xtext.java.tests/src/org/eclipse/xtext/java/tests/MySuperClass2.java
+++ b/org.eclipse.xtext.java.tests/src/org/eclipse/xtext/java/tests/MySuperClass2.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2017 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+package org.eclipse.xtext.java.tests;
+
+/**
+ * Just a class to test class name shadowing
+ * @author Christian Dietrich
+ */
+public class MySuperClass2 {
+
+}

--- a/org.eclipse.xtext.java.tests/xtend-gen/org/eclipse/xtext/java/tests/JavaSourceLanguageTest.java
+++ b/org.eclipse.xtext.java.tests/xtend-gen/org/eclipse/xtext/java/tests/JavaSourceLanguageTest.java
@@ -176,6 +176,42 @@ public class JavaSourceLanguageTest {
     Assert.assertSame(annotation, annotationRef.getAnnotation());
   }
   
+  @Test
+  public void testClassShadowing() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package org.eclipse.xtext.java.tests;");
+    _builder.newLine();
+    _builder.append("public class MySuperClass2 {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("public void doSomething() {");
+    _builder.newLine();
+    _builder.append("        ");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    Pair<String, String> _mappedTo = Pair.<String, String>of("org/eclipse/xtext/java/tests/MySuperClass2.java", _builder.toString());
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package org.eclipse.xtext.java.tests;");
+    _builder_1.newLine();
+    _builder_1.append("public class MySubClass2 extends MySuperClass2 {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    Pair<String, String> _mappedTo_1 = Pair.<String, String>of("org/eclipse/xtext/java/tests/MySubClass2.java", _builder_1.toString());
+    final XtextResourceSet rs = this.resourceSet(_mappedTo, _mappedTo_1);
+    final Function1<Resource, Boolean> _function = (Resource it) -> {
+      return Boolean.valueOf(it.getURI().toString().endsWith("MySuperClass2.java"));
+    };
+    final Resource superResource = IterableExtensions.<Resource>findFirst(rs.getResources(), _function);
+    EObject _head = IterableExtensions.<EObject>head(superResource.getContents());
+    final JvmGenericType clazz = ((JvmGenericType) _head);
+    Assert.assertNotNull(IterableExtensions.<JvmOperation>head(clazz.getDeclaredOperations()));
+  }
+  
   @Inject
   private Provider<XtextResourceSet> resourceSetProvider;
   

--- a/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/InMemoryClassLoader.xtend
+++ b/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/InMemoryClassLoader.xtend
@@ -24,6 +24,25 @@ class InMemoryClassLoader extends ClassLoader {
 		}
 	}
 
+	override getResource(String path) {
+		if (path.endsWith(".class")) {
+			val className = pathToClassName(path)
+			val bytes = classMap.get(className)
+			if (bytes !== null) {
+				return new URL("in-memory", null, -1, path, [
+					new URLConnection(it) {
+						override void connect() {}
+
+						override InputStream getInputStream() {
+							return new ByteArrayInputStream(bytes)
+						}
+					}
+				])
+			}
+		}
+		super.getResource(path)
+	}
+
 	override protected findResource(String path) {
 		if (path.endsWith(".class")) {
 			val className = pathToClassName(path)

--- a/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/InMemoryClassLoader.java
+++ b/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/InMemoryClassLoader.java
@@ -29,6 +29,42 @@ public class InMemoryClassLoader extends ClassLoader {
   }
   
   @Override
+  public URL getResource(final String path) {
+    try {
+      URL _xblockexpression = null;
+      {
+        boolean _endsWith = path.endsWith(".class");
+        if (_endsWith) {
+          final String className = this.pathToClassName(path);
+          final byte[] bytes = this.classMap.get(className);
+          if ((bytes != null)) {
+            final URLStreamHandler _function = new URLStreamHandler() {
+              @Override
+              protected URLConnection openConnection(final URL it) throws IOException {
+                return new URLConnection(it) {
+                  @Override
+                  public void connect() {
+                  }
+                  
+                  @Override
+                  public InputStream getInputStream() {
+                    return new ByteArrayInputStream(bytes);
+                  }
+                };
+              }
+            };
+            return new URL("in-memory", null, (-1), path, _function);
+          }
+        }
+        _xblockexpression = super.getResource(path);
+      }
+      return _xblockexpression;
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Override
   protected URL findResource(final String path) {
     try {
       boolean _endsWith = path.endsWith(".class");


### PR DESCRIPTION
Fixed issue in impl of InMemoryClassLoader.getResource(String) preventing from name shadowing for types working correct #166

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>