### PR TITLE
fixed check for type guards with generic types in switch expression 

### DIFF
--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.xtend
@@ -354,6 +354,37 @@ class XbaseValidationTest extends AbstractXbaseTestCase {
 		'''.expression.assertNoErrors
 	}
 	
+	@Test def void testUnreachableCase_6() {
+		'''
+			switch new java.util.ArrayList<String> {
+				java.util.List<Integer>: "list of integers"
+				java.util.List<String>: "list of strings"
+				default: "something else"
+			}
+		'''.expression.assertError(TypesPackage.Literals.JVM_PARAMETERIZED_TYPE_REFERENCE, IssueCodes.UNREACHABLE_CASE)
+	}
+	
+	@Test def void testUnreachableCase_7() {
+		'''
+			switch new java.util.ArrayList<String> {
+				java.util.List<Integer>: "list of integers"
+				java.util.Set<String>: "set of strings"
+				default: "something else"
+			}
+		'''.expression.assertNoErrors
+	}
+	
+		
+	@Test def void testUnreachableCase_8() {
+		'''
+			switch new java.util.ArrayList<String> {
+				java.util.List: "list of integers"
+				java.util.List<String>: "list of strings"
+				default: "something else"
+			}
+		'''.expression.assertError(TypesPackage.Literals.JVM_PARAMETERIZED_TYPE_REFERENCE, IssueCodes.UNREACHABLE_CASE)
+	}
+	
 	@Test def void testUnreachableCatchClause() {
 		'''
 			try {

--- a/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.java
+++ b/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.java
@@ -795,6 +795,75 @@ public class XbaseValidationTest extends AbstractXbaseTestCase {
   }
   
   @Test
+  public void testUnreachableCase_6() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("switch new java.util.ArrayList<String> {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("java.util.List<Integer>: \"list of integers\"");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("java.util.List<String>: \"list of strings\"");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("default: \"something else\"");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      this._validationTestHelper.assertError(this.expression(_builder), TypesPackage.Literals.JVM_PARAMETERIZED_TYPE_REFERENCE, IssueCodes.UNREACHABLE_CASE);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testUnreachableCase_7() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("switch new java.util.ArrayList<String> {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("java.util.List<Integer>: \"list of integers\"");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("java.util.Set<String>: \"set of strings\"");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("default: \"something else\"");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      this._validationTestHelper.assertNoErrors(this.expression(_builder));
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testUnreachableCase_8() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("switch new java.util.ArrayList<String> {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("java.util.List: \"list of integers\"");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("java.util.List<String>: \"list of strings\"");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("default: \"something else\"");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      this._validationTestHelper.assertError(this.expression(_builder), TypesPackage.Literals.JVM_PARAMETERIZED_TYPE_REFERENCE, IssueCodes.UNREACHABLE_CASE);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
   public void testUnreachableCatchClause() {
     try {
       StringConcatenation _builder = new StringConcatenation();


### PR DESCRIPTION
fixed check for type guards with generic types in switch expression 
https://github.com/eclipse/xtext-xtend/issues/268

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>