### PR TITLE
Improve performance of BatchLinkableResourceStorageLoadable

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.xtend
@@ -8,6 +8,7 @@
 package org.eclipse.xtext.xbase.resource
 
 import com.google.common.collect.Sets
+import java.io.BufferedInputStream
 import java.io.IOException
 import java.io.ObjectInputStream
 import java.util.Map
@@ -57,7 +58,7 @@ import org.eclipse.xtext.xbase.jvmmodel.JvmModelAssociator
 			]) 
 		
 		stream.nextEntry
-		val objIn = new ObjectInputStream(stream)
+		val objIn = new ObjectInputStream(new BufferedInputStream(stream))
 		val logicalMap = objIn.readObject as Map<String,String>
 		logicalMap.entrySet.forEach [
 			adapter.logicalContainerMap.put(resource.getEObject(key), resource.getEObject(value) as JvmIdentifiableElement)

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.java
@@ -9,6 +9,7 @@ package org.eclipse.xtext.xbase.resource;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -99,7 +100,8 @@ public class BatchLinkableResourceStorageLoadable extends ResourceStorageLoadabl
       }
       final JvmModelAssociator.Adapter adapter = _elvis;
       stream.getNextEntry();
-      final ObjectInputStream objIn = new ObjectInputStream(stream);
+      BufferedInputStream _bufferedInputStream = new BufferedInputStream(stream);
+      final ObjectInputStream objIn = new ObjectInputStream(_bufferedInputStream);
       Object _readObject = objIn.readObject();
       final Map<String, String> logicalMap = ((Map<String, String>) _readObject);
       final Consumer<Map.Entry<String, String>> _function_1 = (Map.Entry<String, String> it) -> {


### PR DESCRIPTION
Wrap ZipInputStream in a BufferedInputStream before reading from it with
with ObjectInputStream. This improves performance quite significantly
(overall roughly by a factor 4), as the decompression works much more
efficiently with larger chunks of data. See eclipse/xtext-core#481 for
details.

Signed-off-by: Knut Wannheden <knut.wannheden@paranor.ch>