### PR TITLE
[eclipse/xtext-eclipse#463] Fix for issue

### DIFF
--- a/org.eclipse.xtext.purexbase/src/org/eclipse/xtext/purexbase/GeneratePureXbase.mwe2
+++ b/org.eclipse.xtext.purexbase/src/org/eclipse/xtext/purexbase/GeneratePureXbase.mwe2
@@ -59,6 +59,10 @@ Workflow {
 			formatter = {
 				generateStub = true
 			}
+			
+			editor = {
+				generateStub = false
+			}
 		}
 	}
 }


### PR DESCRIPTION
Excluded EditorFragment2 from Xbase since Xbase already has a manually defined subclass of XtextEditor.

Main part of the fix for [eclipse/xtext-eclipse#463] is in pull request [eclipse/xtext-core#561]

Signed-off-by: Florian Stolte <fstolte@itemis.de>