### PR TITLE
made constructor of FeatureScopeTracker public #199

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/FeatureScopeTracker.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/FeatureScopeTracker.java
@@ -28,7 +28,7 @@ public class FeatureScopeTracker implements IFeatureScopeTracker {
 
 	private final Map<EObject, EnumMap<IExpressionScope.Anchor, ExpressionScope>> featureScopeSessions;
 	
-	protected FeatureScopeTracker() {
+	public FeatureScopeTracker() {
 		featureScopeSessions = Maps.newHashMapWithExpectedSize(256);
 	}
 	


### PR DESCRIPTION
made constructor of FeatureScopeTracker public so it can be instantiated more easily by subclasses of OptimizingFeatureScopeTrackerProvider #199

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>