### PR TITLE
[eclipse/xtext-eclipse#463] Removed references to EditorFragment2

### DIFF
--- a/org.eclipse.xtext.purexbase/src/org/eclipse/xtext/purexbase/GeneratePureXbase.mwe2
+++ b/org.eclipse.xtext.purexbase/src/org/eclipse/xtext/purexbase/GeneratePureXbase.mwe2
@@ -59,10 +59,6 @@ Workflow {
 			formatter = {
 				generateStub = true
 			}
-			
-			editor = {
-				generateStub = false
-			}
 		}
 	}
 }


### PR DESCRIPTION
Adjustments due to the changes in [eclipse/xtext-core#574]:

- removed reference to EditorFragment2 from GeneratePureXbase.mwe2

Signed-off-by: Florian Stolte <fstolte@itemis.de>