### PR TITLE
[eclipse/xtext#1152] Java 9 - Added Automatic-Module-Name header

### DIFF
--- a/org.eclipse.xtext.builder.standalone.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.builder.standalone.tests/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Export-Package: org.eclipse.xtext.builder.tests.builderTestLanguage,
  org.eclipse.xtext.builder.tests.parser.antlr.internal,
  org.eclipse.xtext.builder.tests.validation
 Import-Package: org.apache.log4j
+Automatic-Module-Name: org.eclipse.xtext.builder.standalone.tests

--- a/org.eclipse.xtext.builder.standalone.tests/test-data/model.in.eclipse.project/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.builder.standalone.tests/test-data/model.in.eclipse.project/META-INF/MANIFEST.MF
@@ -1,3 +1,4 @@
 Manifest-Version: 1.0
 Bundle-SymbolicName: model.in.eclipse.project
 Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: model.in.eclipse.project

--- a/org.eclipse.xtext.builder.standalone/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.builder.standalone/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
 Export-Package: org.eclipse.xtext.builder.standalone;x-internal:=true,
  org.eclipse.xtext.builder.standalone.compiler;x-internal:=true,
  org.eclipse.xtext.builder.standalone.incremental;x-internal:=true
+Automatic-Module-Name: org.eclipse.xtext.builder.standalone

--- a/org.eclipse.xtext.common.types.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.common.types.tests/META-INF/MANIFEST.MF
@@ -49,3 +49,4 @@ Import-Package: org.apache.log4j,
  org.junit;version="4.5.0",
  org.junit.runner;version="4.5.0",
  org.junit.runners;version="4.5.0"
+Automatic-Module-Name: org.eclipse.xtext.common.types.tests

--- a/org.eclipse.xtext.common.types/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.common.types/META-INF/MANIFEST.MF
@@ -33,3 +33,4 @@ Export-Package: org.eclipse.xtext.common.types,
    org.eclipse.xtext.xbase.ide,
    org.eclipse.xtend.ide.common",
  org.eclipse.xtext.common.types.xtext;x-friends:="org.eclipse.xtext.common.types.ui"
+Automatic-Module-Name: org.eclipse.xtext.common.types

--- a/org.eclipse.xtext.ecore/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ecore/META-INF/MANIFEST.MF
@@ -10,3 +10,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.xtext.ecore
 Import-Package: org.apache.log4j;version="1.2.15"
+Automatic-Module-Name: org.eclipse.xtext.ecore

--- a/org.eclipse.xtext.extras.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.extras.tests/META-INF/MANIFEST.MF
@@ -45,3 +45,4 @@ Require-Bundle: org.antlr.runtime,
  org.eclipse.xtext.xbase.lib
 Import-Package: org.apache.log4j
 Bundle-Vendor: Eclipse Xtext
+Automatic-Module-Name: org.eclipse.xtext.extras.tests

--- a/org.eclipse.xtext.generator/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.generator/META-INF/MANIFEST.MF
@@ -72,3 +72,4 @@ Bundle-ActivationPolicy: lazy
 Import-Package: com.ibm.icu.text;version="4.0.0",
  org.apache.commons.logging;version="1.0.4";resolution:=optional;x-installation:=greedy,
  org.apache.log4j;version="1.2.15"
+Automatic-Module-Name: org.eclipse.xtext.generator

--- a/org.eclipse.xtext.java/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.java/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Require-Bundle: org.eclipse.xtext,
 Export-Package: org.eclipse.xtext.java,
  org.eclipse.xtext.java.resource
 Import-Package: org.apache.log4j;version="1.2.15"
+Automatic-Module-Name: org.eclipse.xtext.java

--- a/org.eclipse.xtext.purexbase.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.purexbase.ide/META-INF/MANIFEST.MF
@@ -12,4 +12,4 @@ Require-Bundle: org.eclipse.xtext.purexbase,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.purexbase.ide.contentassist.antlr,
  org.eclipse.xtext.purexbase.ide.contentassist.antlr.internal
-
+Automatic-Module-Name: org.eclipse.xtext.purexbase.ide

--- a/org.eclipse.xtext.purexbase.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.purexbase.tests/META-INF/MANIFEST.MF
@@ -28,3 +28,4 @@ Import-Package: org.apache.commons.logging,
  org.junit.runners.model;version="4.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.purexbase.tests;x-internal=true
+Automatic-Module-Name: org.eclipse.xtext.purexbase.tests

--- a/org.eclipse.xtext.purexbase/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.purexbase/META-INF/MANIFEST.MF
@@ -32,4 +32,4 @@ Export-Package: org.eclipse.xtext.purexbase,
  org.eclipse.xtext.purexbase.serializer,
  org.eclipse.xtext.purexbase.scoping,
  org.eclipse.xtext.purexbase.formatting2
-
+Automatic-Module-Name: org.eclipse.xtext.purexbase

--- a/org.eclipse.xtext.smap/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.smap/META-INF/MANIFEST.MF
@@ -8,3 +8,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.smap;x-internal:=true
 Require-Bundle: org.eclipse.xtext
 Import-Package: org.apache.log4j;version="1.2.15"
+Automatic-Module-Name: org.eclipse.xtext.smap

--- a/org.eclipse.xtext.xbase.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.ide/META-INF/MANIFEST.MF
@@ -19,4 +19,4 @@ Export-Package: org.eclipse.xtext.xbase.annotations.ide.contentassist.antlr;x-fr
  org.eclipse.xtext.xbase.ide.contentassist.antlr.internal;x-friends:="org.eclipse.xtext.xbase.ui",
  org.eclipse.xtext.xbase.ide.highlighting;x-friends:="org.eclipse.xtext.xbase.ui,org.eclipse.xtend.ide,org.eclipse.xtend.ide.common",
  org.eclipse.xtext.xbase.ide.types;x-friends:="org.eclipse.xtext.xbase.ui"
-
+Automatic-Module-Name: org.eclipse.xtext.xbase.ide

--- a/org.eclipse.xtext.xbase.testing/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.testing/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Export-Package: org.eclipse.xtext.xbase.testing,
  testdata.a;x-internal:=true,
  testdata.b;x-internal:=true
 Import-Package: org.apache.log4j;version="1.2.15"
+Automatic-Module-Name: org.eclipse.xtext.xbase.testing

--- a/org.eclipse.xtext.xbase.testlanguages.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.testlanguages.ide/META-INF/MANIFEST.MF
@@ -16,4 +16,4 @@ Export-Package: org.eclipse.xtext.xbase.testlanguages.bug462047.ide,
  org.eclipse.xtext.xbase.testlanguages.ide,
  org.eclipse.xtext.xbase.testlanguages.ide.contentassist.antlr,
  org.eclipse.xtext.xbase.testlanguages.ide.contentassist.antlr.internal
-
+Automatic-Module-Name: org.eclipse.xtext.xbase.testlanguages.ide

--- a/org.eclipse.xtext.xbase.testlanguages/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.testlanguages/META-INF/MANIFEST.MF
@@ -56,4 +56,4 @@ Export-Package: org.eclipse.xtext.xbase.testlanguages,
  org.eclipse.xtext.xbase.testlanguages.bug462047.jvmmodel,
  org.eclipse.xtext.xbase.testlanguages.tests;x-internal=true,
  org.eclipse.xtext.xbase.testlanguages.bug462047.tests;x-internal=true
-
+Automatic-Module-Name: org.eclipse.xtext.xbase.testlanguages

--- a/org.eclipse.xtext.xbase.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.tests/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Import-Package: javax.inject;version="1.0.0",
  org.junit.rules;version="4.7.0",
  org.junit.runner;version="4.7.0",
  org.junit.runners;version="4.7.0"
+Automatic-Module-Name: org.eclipse.xtext.xbase.tests

--- a/org.eclipse.xtext.xbase/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase/META-INF/MANIFEST.MF
@@ -120,3 +120,4 @@ Export-Package: org.eclipse.xtext.xbase,
 Import-Package: com.ibm.icu.text;version="4.0.0";resolution:=optional,
  javax.annotation,
  org.apache.log4j;version="1.2.15"
+Automatic-Module-Name: org.eclipse.xtext.xbase


### PR DESCRIPTION
Signed-off-by: Florian Stolte <fstolte@itemis.de>