### PR TITLE
[411549] Support multicatch and multitype guards in Xtend

### DIFF
--- a/gradle/upstream-repositories.gradle
+++ b/gradle/upstream-repositories.gradle
@@ -24,7 +24,7 @@ repositories {
 	jcenter()
 	if (findProperty('useJenkinsSnapshots') == 'true') {
 		maven { url "http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/" }
-		maven { url 'http://services.typefox.io/open-source/jenkins/job/xtext-lib/job/sz%252Fbug411549/lastSuccessfulBuild/artifact/build/maven-repository/' }
+		maven { url jenkinsPipelineRepo('xtext-lib') }
 		maven { url 'http://services.typefox.io/open-source/jenkins/job/xtext-core/job/sz%252Fbug411549/lastSuccessfulBuild/artifact/build/maven-repository/' }
 	} else {
 		mavenLocal()

--- a/gradle/upstream-repositories.gradle
+++ b/gradle/upstream-repositories.gradle
@@ -25,7 +25,7 @@ repositories {
 	if (findProperty('useJenkinsSnapshots') == 'true') {
 		maven { url "http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/" }
 		maven { url jenkinsPipelineRepo('xtext-lib') }
-		maven { url 'http://services.typefox.io/open-source/jenkins/job/xtext-core/job/sz%252Fbug411549/lastSuccessfulBuild/artifact/build/maven-repository/' }
+		maven { url jenkinsPipelineRepo('xtext-core') }
 	} else {
 		mavenLocal()
 		maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }

--- a/gradle/upstream-repositories.gradle
+++ b/gradle/upstream-repositories.gradle
@@ -24,8 +24,8 @@ repositories {
 	jcenter()
 	if (findProperty('useJenkinsSnapshots') == 'true') {
 		maven { url "http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/" }
-		maven { url jenkinsPipelineRepo('xtext-lib') }
-		maven { url jenkinsPipelineRepo('xtext-core') }
+		maven { url 'http://services.typefox.io/open-source/jenkins/job/xtext-lib/job/sz%252Fbug411549/lastSuccessfulBuild/artifact/build/maven-repository/' }
+		maven { url 'http://services.typefox.io/open-source/jenkins/job/xtext-core/job/sz%252Fbug411549/lastSuccessfulBuild/artifact/build/maven-repository/' }
 	} else {
 		mavenLocal()
 		maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/junit/evaluation/AbstractXbaseEvaluationTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/junit/evaluation/AbstractXbaseEvaluationTest.java
@@ -2499,6 +2499,20 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	@Test public void testSwitchExpression_55() throws Exception {
 		assertEvaluatesTo(null, "{ switch (Thread.State x : Thread.State.NEW) { default: { } } }");
 	}
+	
+	@Ignore("Multi refs are not supported in Xbase")
+	@Test public void testSwitchExpression_56() throws Exception {
+		assertEvaluatesTo(0, 
+				"{ switch x : 'lalala' as Object { String | Integer: 0 " +
+												"Long, default: 1 } }");
+	}
+	
+	@Ignore("Multi refs are not supported in Xbase")
+	@Test public void testSwitchExpression_57() throws Exception {
+		assertEvaluatesTo(0, 
+				"{ switch x : Integer.valueOf(2) as Object { String | Integer case x.toString == '2': 0 " +
+												"Integer, default: 1 } }");
+	}
 
 	@Test public void testSwitchExpressionOverEnum() throws Exception {
 		assertEvaluatesTo(1, 
@@ -2670,6 +2684,14 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 		assertEvaluatesWithException(NullPointerException.class, 
 				"try 'literal' as Object as Boolean" +
 				"  catch(ClassCastException e) throw new NullPointerException" +
+				"  catch(NullPointerException e) 'dont catch subsequent exceptions'");
+	}
+	
+	@Ignore("Multi catch is not supported in Xbase")
+	@Test public void testTryCatch_10() throws Exception {
+		assertEvaluatesWithException(NullPointerException.class, 
+				"try 'literal' as Object as Boolean" +
+				"  catch(IllegalArgumentException | ClassCastException e) throw new NullPointerException" +
 				"  catch(NullPointerException e) 'dont catch subsequent exceptions'");
 	}
 	

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/jvmmodel/CheckExceptionValidationTest.xtend
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/jvmmodel/CheckExceptionValidationTest.xtend
@@ -14,7 +14,7 @@ class CheckExceptionValidationTest extends AbstractJvmModelTest {
 	
 	@Inject ValidationTestHelper helper
 	
-	private MapBasedPreferenceValues preferences;
+	MapBasedPreferenceValues preferences;
 	
 	@Inject
 	def void setPreferences(SingletonPreferenceValuesProvider prefProvider) {

--- a/org.eclipse.xtext.xbase/generator/org/eclipse/xtext/xbase/GenerateXbase.java
+++ b/org.eclipse.xtext.xbase/generator/org/eclipse/xtext/xbase/GenerateXbase.java
@@ -44,7 +44,7 @@ final class GenerateXbase {
 		final boolean memoize = false;
 		final String lineDelimiter = "\n";
 		final String fileHeader = "/*******************************************************************************\n" +
-			" * Copyright (c) 2010-${year} itemis AG (http://www.itemis.eu) and others.\n" +
+			" * Copyright (c) 2010, ${year} itemis AG (http://www.itemis.eu) and others.\n" +
 			" * All rights reserved. This program and the accompanying materials\n" +
 			" * are made available under the terms of the Eclipse Public License v1.0\n" +
 			" * which accompanies this distribution, and is available at\n" +

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/TypeConvertingCompiler.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/TypeConvertingCompiler.java
@@ -17,6 +17,7 @@ import org.eclipse.xtext.common.types.JvmGenericType;
 import org.eclipse.xtext.common.types.JvmIdentifiableElement;
 import org.eclipse.xtext.common.types.JvmOperation;
 import org.eclipse.xtext.common.types.JvmType;
+import org.eclipse.xtext.common.types.JvmTypeReference;
 import org.eclipse.xtext.common.types.JvmVoid;
 import org.eclipse.xtext.xbase.XAbstractFeatureCall;
 import org.eclipse.xtext.xbase.XBlockExpression;
@@ -135,6 +136,12 @@ public class TypeConvertingCompiler extends AbstractXbaseCompiler {
 				LightweightTypeReference featureType = resolvedTypes.getActualType(((XAbstractFeatureCall) expression).getFeature());
 				if (featureType != null && !featureType.isMultiType() && actualType.isAssignableFrom(featureType)) {
 					return false;
+				}
+				if (featureType != null && featureType.isMultiType()) {
+					JvmTypeReference compliantTypeReference = featureType.toJavaCompliantTypeReference();
+					if (actualType.isAssignableFrom(featureType.getOwner().toLightweightTypeReference(compliantTypeReference))) {
+						return false;
+					}
 				}
 			}
 			if (expression.eContainer() instanceof XCastedExpression) {

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/ThrownExceptionSwitch.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/ThrownExceptionSwitch.java
@@ -92,7 +92,11 @@ public class ThrownExceptionSwitch extends XbaseSwitch<Boolean> {
 				if (caughtException.isType(Throwable.class)) {
 					wasThrowable = true;
 				}
-				caughtExceptions.add(caughtException);
+				if (caughtException.isSynonym()) {
+					caughtExceptions.addAll(caughtException.getMultiTypeComponents());	
+				} else {
+					caughtExceptions.add(caughtException);
+				}
 			}
 			delegate.collectThrownExceptions(clause.getExpression());
 		}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/IssueCodes.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/IssueCodes.java
@@ -163,6 +163,11 @@ public class IssueCodes extends org.eclipse.xtext.validation.IssueCodes {
 	
 	public static final String REFER_INVALID_TYPES = ISSUE_CODE_PREFIX + "refer_invalid_types";
 	
+	/**
+	 * A multitype `A | B` where A is a subtype of B or vice versa.
+	 */
+	public static final String INVALID_MULTITYPE_PART = ISSUE_CODE_PREFIX + "invalid_multitype_part";
+	
 	private IssueCodes() {
 	}
 


### PR DESCRIPTION
Here we play catch-up with Java by supporting multiple types in catch clauses:

`try { mayThrowException } catch(IllegalArgumentException | IllegalStateException e) { .. }`

We also enable intersection types in switch type guards:

`switch(e) { IllegalArgumentException | IllegalStateException case e.message == 'Whoot': .. }`