### PR TITLE
[460455] Avoid fully qualifying names when organizing imports.

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/ConflictResolver.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/ConflictResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -65,7 +65,7 @@ public class ConflictResolver {
 						? localTypes.iterator().next() 
 						: null; 
 				for (JvmDeclaredType type : types) {
-					if(type == singleLocalType)
+					if(type == singleLocalType || types.size()==1)
 						result.put(type.getSimpleName(), type);
 					else 
 						result.put(type.getQualifiedName('.'), type);


### PR DESCRIPTION
- Modify the Xbase ConflictResolver not to fully qualify type names if
two types (one as inner type, one as top-level type) with the same name
exists. In such case, the usage of the fully qualified name is
unnecessary, since the inner type has precedence anyway.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>