### PR TITLE
[#249] Fix failing test cases in the Domain-Model Example.

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/ConflictResolver.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/ConflictResolver.java
@@ -65,7 +65,7 @@ public class ConflictResolver {
 						? localTypes.iterator().next() 
 						: null; 
 				for (JvmDeclaredType type : types) {
-					if(type == singleLocalType || locallyDefinedTypes.values().contains(type))
+					if(type == singleLocalType || (locallyDefinedTypes.values().contains(type) && types.size()==1))
 						result.put(type.getSimpleName(), type);
 					else 
 						result.put(type.getQualifiedName('.'), type);


### PR DESCRIPTION
- Make the OrtanizeImportsTest.tetLocalNameClash test case succeed
again.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>