### PR TITLE
[eclipse/xtext#1177] HACK: Support java 10 with ASM 6.0

### DIFF
--- a/org.eclipse.xtext.common.types/src/org/eclipse/xtext/common/types/access/binary/asm/ClassFileBytesAccess.java
+++ b/org.eclipse.xtext.common.types/src/org/eclipse/xtext/common/types/access/binary/asm/ClassFileBytesAccess.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import com.google.common.collect.Maps;
  * <p>It is not expected to be used concurrently.</p>
  * 
  * @author Sebastian Zarnekow - Initial contribution and API
+ * @author Arne Deutsch - Introduce hack to work with Java 10 and ASM 6.0
  */
 public class ClassFileBytesAccess {
 
@@ -53,6 +54,20 @@ public class ClassFileBytesAccess {
 			return result != notAvailable ? result : null;
 		}
 		result = clazz.getBytes();
+		
+		// XXX This is a hack to be able to work with ASM 6.0 which is not Java 10 compatible. As ASM 6.1 is buggy
+		// and ASM 6.1.1 not yet released we check if the loaded class is compiled with Java 10. If so we modify the
+		// major version byte from 54 (Java 10) to 53 (Java 9). The the byte codes between both versions are otherwise
+		// unchanged this is not critical.
+		// TODO remove hack as soon as ASM 6.1.1 is included in eclipse and we can remove backwards compatibility with
+		// eclipse oxygen 3a and probabably eclipse photon
+		
+		// START HACK
+		if (result[7] == 54) {
+			result[7] = 53;
+		}
+		// END HACK
+		
 		cache.put(className, result != null ? result : notAvailable);
 		return result;
 	}


### PR DESCRIPTION
This is a hack to be able to work with ASM 6.0 which is not Java 10
compatible. As ASM 6.1 is buggy and ASM 6.1.1 not yet released we check
if the loaded class is compiled with Java 10. If so we modify the major
version byte from 54 (Java 10) to 53 (Java 9). The the byte codes
between both versions are otherwise unchanged this is not critical.

We should remove the hack as soon as ASM 6.1.1 is included in eclipse
and we can remove backwards compatibility with eclipse oxygen 3a and
probabably eclipse photon (depending what ASM version will be shiped
with photon in the end).


Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>