### PR TITLE
[eclipse/xtext#1190] Narrowed the version range for asm to [6.1.1,6.2.0)

### DIFF
--- a/org.eclipse.xtext.common.types.tests/META-INF/MANIFEST.MF_gen
+++ b/org.eclipse.xtext.common.types.tests/META-INF/MANIFEST.MF_gen
@@ -6,7 +6,7 @@ Bundle-Version: 0.0.1
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.xtext.common.types.xtext.ui
-Require-Bundle: org.objectweb.asm;bundle-version="[6.1.1,7.0.0)";resolution:=optional,
+Require-Bundle: org.objectweb.asm;bundle-version="[6.1.1,6.2.0)";resolution:=optional,
  org.eclipse.xtext.common.types.tests,
  org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.lib,

--- a/org.eclipse.xtext.common.types/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.common.types/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle:
  com.google.inject;bundle-version="3.0.0",
  org.eclipse.xtext,
  org.eclipse.emf.mwe2.lib;bundle-version="2.2.0";resolution:=optional;x-installation:=greedy,
- org.objectweb.asm;bundle-version="[6.1.1,7.0.0)",
+ org.objectweb.asm;bundle-version="[6.1.1,6.2.0)",
  org.eclipse.xtend.lib,
  com.google.guava;bundle-version="[14.0.0,22.0.0)"
 Import-Package: org.apache.commons.logging;version="1.0.4";resolution:=optional,

--- a/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/types/TypesGeneratorFragment.java
+++ b/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/types/TypesGeneratorFragment.java
@@ -44,12 +44,12 @@ public class TypesGeneratorFragment extends DefaultGeneratorFragment implements 
 
 	@Override
 	public String[] getRequiredBundlesRt(Grammar grammar) {
-		return new String[] { "org.eclipse.xtext.common.types","org.objectweb.asm;bundle-version=\"[6.1.1,7.0.0)\";resolution:=optional" };
+		return new String[] { "org.eclipse.xtext.common.types","org.objectweb.asm;bundle-version=\"[6.1.1,6.2.0)\";resolution:=optional" };
 	}
 	
 	@Override
 	public String[] getRequiredBundlesTests(Grammar grammar) {
-		return new String[] { "org.objectweb.asm;bundle-version=\"[6.1.1,7.0.0)\";resolution:=optional" };
+		return new String[] { "org.objectweb.asm;bundle-version=\"[6.1.1,6.2.0)\";resolution:=optional" };
 	}
 
 	@Override

--- a/org.eclipse.xtext.purexbase.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.purexbase.tests/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.xtext.purexbase,
  org.eclipse.xtext.xbase.junit,
  org.eclipse.xtext.builder,
  org.eclipse.jdt.core;bundle-version="3.6.0",
- org.objectweb.asm;bundle-version="[6.1.1,7.0.0)";resolution:=optional,
+ org.objectweb.asm;bundle-version="[6.1.1,6.2.0)";resolution:=optional,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
  org.eclipse.xtext.xbase.testing
 Import-Package: org.apache.commons.logging,

--- a/org.eclipse.xtext.purexbase/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.purexbase/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtend.lib;bundle-version="2.14.0",
  org.eclipse.emf.common,
  org.eclipse.xtext.common.types,
- org.objectweb.asm;bundle-version="[6.1.1,7.0.0)";resolution:=optional
+ org.objectweb.asm;bundle-version="[6.1.1,6.2.0)";resolution:=optional
 Import-Package: org.apache.commons.logging,
  org.apache.log4j;version="1.2.15"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.xtext.xbase.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.ide/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase;visibility:=reexport,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
- org.objectweb.asm;bundle-version="[6.1.1,7.0.0)",
+ org.objectweb.asm;bundle-version="[6.1.1,6.2.0)",
  org.antlr.runtime
 Export-Package: org.eclipse.xtext.xbase.annotations.ide.contentassist.antlr;x-friends:="org.eclipse.xtext.xbase.ui",
  org.eclipse.xtext.xbase.annotations.ide.contentassist.antlr.internal;x-friends:="org.eclipse.xtext.xbase.ui",

--- a/org.eclipse.xtext.xbase.testdata/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.testdata/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase;visibility:=reexport,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
- org.objectweb.asm;bundle-version="[6.1.1,7.0.0)",
+ org.objectweb.asm;bundle-version="[6.1.1,6.2.0)",
  org.antlr.runtime
 Automatic-Module-Name: org.eclipse.xtext.xbase.ide
 Export-Package: closures,

--- a/org.eclipse.xtext.xbase.testlanguages/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.testlanguages/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.antlr.runtime,
  org.eclipse.xtext.common.types,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
- org.objectweb.asm;bundle-version="[6.1.1,7.0.0)";resolution:=optional,
+ org.objectweb.asm;bundle-version="[6.1.1,6.2.0)";resolution:=optional,
  org.eclipse.xtext.xbase.testing,
  org.eclipse.xtext.testing
 Import-Package: org.apache.log4j,

--- a/org.eclipse.xtext.xbase/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.xtext,
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
  org.eclipse.xtend.lib;visibility:=reexport,
- org.objectweb.asm;bundle-version="[6.1.1,7.0.0)";resolution:=optional
+ org.objectweb.asm;bundle-version="[6.1.1,6.2.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.xbase,
  org.eclipse.xtext.xbase.annotations;x-friends:="org.eclipse.xtext.xbase.ide,


### PR DESCRIPTION
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>