### PR TITLE
[eclipse/xtext-xtend#461] Avoid stackoverflow in type inferrence

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/computation/AbstractClosureTypeHelper.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/computation/AbstractClosureTypeHelper.java
@@ -91,7 +91,9 @@ public abstract class AbstractClosureTypeHelper implements IClosureCandidate {
 					if (source == BoundTypeArgumentSource.INFERRED_CONSTRAINT) {
 						wrapped = getStricterConstraint(typeParameter, wrapped);
 					}
-					typeParameter.acceptHint(wrapped, source, getOrigin(), getExpectedVariance(), getActualVariance());
+					if (wrapped != null) {
+						typeParameter.acceptHint(wrapped, source, getOrigin(), getExpectedVariance(), getActualVariance());	
+					}
 				}
 			};
 			collector.processPairedReferences(declared, actual);

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/computation/XbaseTypeComputer.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/computation/XbaseTypeComputer.java
@@ -744,7 +744,7 @@ public class XbaseTypeComputer extends AbstractTypeComputer implements ITypeComp
 				if (forExpressionType.isAny() || forExpressionType.isUnknown()) {
 					iterableState.refineExpectedType(object.getForExpression(), iterableOrArray);
 				} else if (forExpressionType.isResolved()) {
-					int assignability = iterableOrArray.internalIsAssignableFrom(forExpressionType, new TypeConformanceComputationArgument());
+					int assignability = iterableOrArray.internalIsAssignableFrom(forExpressionType, TypeConformanceComputationArgument.DEFAULT);
 					if ((assignability & ConformanceFlags.SUCCESS) != 0 && (assignability & ConformanceFlags.RAW_TYPE_CONVERSION) == 0)
 						iterableState.refineExpectedType(object.getForExpression(), forExpressionType);
 					else {

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/conformance/RawTypeConformanceComputer.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/conformance/RawTypeConformanceComputer.java
@@ -632,13 +632,8 @@ public class RawTypeConformanceComputer {
 		if (leftHints.isEmpty() && (flags & UNBOUND_COMPUTATION_ADDS_HINTS) == 0) {
 			return flags; 
 		}
-		for(LightweightBoundTypeArgument leftHint: leftHints) {
-			if (leftHint.getSource() == BoundTypeArgumentSource.INFERRED_LATER && leftHint.getActualVariance() == VarianceInfo.INVARIANT) {
-				LightweightTypeReference leftHintReference = leftHint.getTypeReference();
-				if (leftHintReference.getUniqueIdentifier().equals(right.getUniqueIdentifier())) {
-					return flags | SUCCESS;
-				}
-			}
+		if (isConstrainedRecursiveHintCheck(leftHints, right)) {
+			return flags | SUCCESS;
 		}
 		int result = isConformantToConstraints(left, right, leftHints, 
 				flags & ~(AS_TYPE_ARGUMENT | ALLOW_PRIMITIVE_WIDENING | ALLOW_SYNONYMS | ALLOW_FUNCTION_CONVERSION));
@@ -655,6 +650,25 @@ public class RawTypeConformanceComputer {
 			}
 		}
 		return flags;
+	}
+	
+	private boolean isConstrainedRecursiveHintCheck(List<LightweightBoundTypeArgument> leftHints, LightweightTypeReference right) {
+		boolean hasConstraints = false;
+		for(LightweightBoundTypeArgument leftHint: leftHints) {
+			if (leftHint.getSource() == BoundTypeArgumentSource.CONSTRAINT) {
+				hasConstraints = true;
+			}
+			if (leftHint.getSource() == BoundTypeArgumentSource.INFERRED_LATER && leftHint.getActualVariance() == VarianceInfo.INVARIANT) {
+				if (!hasConstraints) {
+					return false;
+				}
+				LightweightTypeReference leftHintReference = leftHint.getTypeReference();
+				if (leftHintReference.getUniqueIdentifier().equals(right.getUniqueIdentifier())) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 	
 	protected int isConformantToConstraints(

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/conformance/RawTypeConformanceComputer.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/conformance/RawTypeConformanceComputer.java
@@ -632,6 +632,14 @@ public class RawTypeConformanceComputer {
 		if (leftHints.isEmpty() && (flags & UNBOUND_COMPUTATION_ADDS_HINTS) == 0) {
 			return flags; 
 		}
+		for(LightweightBoundTypeArgument leftHint: leftHints) {
+			if (leftHint.getSource() == BoundTypeArgumentSource.INFERRED_LATER && leftHint.getActualVariance() == VarianceInfo.INVARIANT) {
+				LightweightTypeReference leftHintReference = leftHint.getTypeReference();
+				if (leftHintReference.getUniqueIdentifier().equals(right.getUniqueIdentifier())) {
+					return flags | SUCCESS;
+				}
+			}
+		}
 		int result = isConformantToConstraints(left, right, leftHints, 
 				flags & ~(AS_TYPE_ARGUMENT | ALLOW_PRIMITIVE_WIDENING | ALLOW_SYNONYMS | ALLOW_FUNCTION_CONVERSION));
 		if ((result & SUCCESS) == 0) {

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/conformance/TypeConformanceComputationArgument.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/conformance/TypeConformanceComputationArgument.java
@@ -13,6 +13,9 @@ package org.eclipse.xtext.xbase.typesystem.conformance;
  */
 public class TypeConformanceComputationArgument {
 
+	public static final TypeConformanceComputationArgument RAW = new TypeConformanceComputationArgument(true, false, true, true, false, true);
+	public static final TypeConformanceComputationArgument DEFAULT = new TypeConformanceComputationArgument();
+	
 	protected final boolean rawType;
 	protected final boolean asTypeArgument;
 	protected final boolean allowPrimitiveConversion;

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/conformance/TypeConformanceComputationArgument.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/conformance/TypeConformanceComputationArgument.java
@@ -13,7 +13,14 @@ package org.eclipse.xtext.xbase.typesystem.conformance;
  */
 public class TypeConformanceComputationArgument {
 
+	/**
+	 * Do not check type arguments but still apply synonym type conversion rules.
+	 */
 	public static final TypeConformanceComputationArgument RAW = new TypeConformanceComputationArgument(true, false, true, true, false, true);
+	
+	/**
+	 * Default Xbase type conformance rules including synonym type conformance checks.
+	 */
 	public static final TypeConformanceComputationArgument DEFAULT = new TypeConformanceComputationArgument();
 	
 	protected final boolean rawType;
@@ -23,6 +30,10 @@ public class TypeConformanceComputationArgument {
 	protected final boolean unboundComputationAddsHints;
 	protected final boolean allowSynonyms;
 	
+	/**
+	 * @deprecated use {@link TypeConformanceComputationArgument#DEFAULT} instead.
+	 */
+	@Deprecated
 	public TypeConformanceComputationArgument() {
 		this(false, false, true, true, false, true);
 	}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/AbstractPendingLinkingCandidate.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/AbstractPendingLinkingCandidate.java
@@ -197,13 +197,19 @@ public abstract class AbstractPendingLinkingCandidate<Expression extends XExpres
 		b.append(typeParameter.getName());
 		ITypeReferenceOwner referenceOwner = getState().getReferenceOwner();
 		if(!typeParameter.getConstraints().isEmpty()) {
+			boolean firstUpperBound = true;
 			for(int j=0; j<typeParameter.getConstraints().size(); ++j) {
 				JvmTypeConstraint constraint = typeParameter.getConstraints().get(j);
 				LightweightTypeReference typeRef = referenceOwner.toLightweightTypeReference(constraint.getTypeReference());
 				if(constraint instanceof JvmUpperBound) {
 					if(typeRef.isType(Object.class))
 						continue;
-					b.append(" extends ");
+					if (firstUpperBound) {
+						b.append(" extends ");
+						firstUpperBound = false;
+					} else {
+						b.append(" & ");
+					}
 				} else 
 					b.append(" super ");
 				b.append(typeRef.getHumanReadableName());
@@ -1047,14 +1053,14 @@ public abstract class AbstractPendingLinkingCandidate<Expression extends XExpres
 	}
 
 	protected int compareDeclaredTypes(LightweightTypeReference left, LightweightTypeReference right, boolean leftResolved, boolean rightResolved) {
-		int rightToLeftConformance = left.internalIsAssignableFrom(right, new TypeConformanceComputationArgument());
+		int rightToLeftConformance = left.internalIsAssignableFrom(right, TypeConformanceComputationArgument.DEFAULT);
 		if ((rightToLeftConformance & ConformanceFlags.SUCCESS) != 0) {
 			if (!right.isAssignableFrom(left) && 
 					(!leftResolved || !rightResolved || ((rightToLeftConformance & ConformanceFlags.RAW_TYPE_CONVERSION) == 0))) {
 				return 1;
 			}
 		} else {
-			int leftToRightConformance = right.internalIsAssignableFrom(left, new TypeConformanceComputationArgument());
+			int leftToRightConformance = right.internalIsAssignableFrom(left, TypeConformanceComputationArgument.DEFAULT);
 			if ((leftToRightConformance & ConformanceFlags.SUCCESS) != 0 && 
 					(!leftResolved || !rightResolved || ((leftToRightConformance & ConformanceFlags.RAW_TYPE_CONVERSION) == 0))) {
 				return -1;

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/ConstructorLinkingCandidate.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/ConstructorLinkingCandidate.java
@@ -76,7 +76,7 @@ public class ConstructorLinkingCandidate extends AbstractPendingLinkingCandidate
 		LightweightTypeReference result = super.deferredBindTypeArgument(expectation, type);
 		LightweightTypeReference expectedType = expectation.getExpectedType();
 		if (expectedType != null && getConstructorCall().getTypeArguments().isEmpty() && !result.isRawType() && !getDeclaredTypeParameters().isEmpty()) {
-			if (!expectedType.isAssignableFrom(result, new TypeConformanceComputationArgument())) {
+			if (!expectedType.isAssignableFrom(result, TypeConformanceComputationArgument.DEFAULT)) {
 				LightweightTypeReference rawFeatureType = result.getRawTypeReference();
 				if (expectedType.isAssignableFrom(rawFeatureType)) {
 					result = rawFeatureType;

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/ResolvedTypes.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/ResolvedTypes.java
@@ -827,7 +827,7 @@ public abstract class ResolvedTypes implements IResolvedTypes {
 			LightweightTypeReference expectedType = expectation.getExpectedType();
 			if (expectedType != null) {
 				int conformanceResult = expectedType.getUpperBoundSubstitute().internalIsAssignableFrom(
-						actualType, new TypeConformanceComputationArgument());
+						actualType, TypeConformanceComputationArgument.DEFAULT);
 				flags |= conformanceResult | ConformanceFlags.CHECKED;
 				flags &= ~ConformanceFlags.UNCHECKED;
 			} else {

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/references/LightweightTypeReference.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/references/LightweightTypeReference.java
@@ -502,8 +502,7 @@ public abstract class LightweightTypeReference {
      * the given {@code reference}.
      */
 	public boolean isAssignableFrom(LightweightTypeReference reference) {
-		TypeConformanceComputationArgument argument = new TypeConformanceComputationArgument();
-		return isAssignableFrom(reference, argument);
+		return isAssignableFrom(reference, TypeConformanceComputationArgument.DEFAULT);
 	}
 	
 	public boolean isAssignableFrom(LightweightTypeReference reference, TypeConformanceComputationArgument argument) {

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/BoundTypeArgumentMerger.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/BoundTypeArgumentMerger.java
@@ -192,7 +192,7 @@ public class BoundTypeArgumentMerger {
 			if (VarianceInfo.OUT.equals(singleArgument.getActualVariance()) && singleArgument.getActualVariance().equals(singleArgument.getDeclaredVariance())) {
 				LightweightTypeReference singleReference = singleArgument.getTypeReference();
 				if (singleReference.isResolved())
-					return candidate.isAssignableFrom(singleReference, new TypeConformanceComputationArgument());
+					return candidate.isAssignableFrom(singleReference, TypeConformanceComputationArgument.DEFAULT);
 			}
 		}
 		LightweightMergedBoundTypeArgument merged = merge(allArguments, candidate.getOwner());
@@ -211,8 +211,8 @@ public class BoundTypeArgumentMerger {
 				}
 				return false;
 			}
-			case OUT: return type.isAssignableFrom(candidate, new TypeConformanceComputationArgument());
-			case IN: return candidate.isAssignableFrom(type, new TypeConformanceComputationArgument());
+			case OUT: return type.isAssignableFrom(candidate, TypeConformanceComputationArgument.DEFAULT);
+			case IN: return candidate.isAssignableFrom(type, TypeConformanceComputationArgument.DEFAULT);
 			default: throw new IllegalStateException("Unknown variance info: " + variance);
 		}
 	}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/DeferredTypeParameterHintCollector.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/DeferredTypeParameterHintCollector.java
@@ -17,6 +17,7 @@ import org.eclipse.xtext.common.types.JvmType;
 import org.eclipse.xtext.common.types.JvmTypeConstraint;
 import org.eclipse.xtext.common.types.JvmTypeParameter;
 import org.eclipse.xtext.common.types.JvmTypeReference;
+import org.eclipse.xtext.xbase.typesystem.conformance.TypeConformanceComputationArgument;
 import org.eclipse.xtext.xbase.typesystem.references.ArrayTypeReference;
 import org.eclipse.xtext.xbase.typesystem.references.CompoundTypeReference;
 import org.eclipse.xtext.xbase.typesystem.references.ITypeReferenceOwner;
@@ -128,7 +129,9 @@ public class DeferredTypeParameterHintCollector extends AbstractTypeReferencePai
 
 	protected void addHint(UnboundTypeReference typeParameter, LightweightTypeReference reference) {
 		LightweightTypeReference wrapped = getStricterConstraint(typeParameter, reference.getWrapperTypeIfPrimitive());
-		typeParameter.acceptHint(wrapped, getTypeArgumentSource(), getOrigin(), getExpectedVariance(), getActualVariance());
+		if (wrapped != null) {
+			typeParameter.acceptHint(wrapped, getTypeArgumentSource(), getOrigin(), getExpectedVariance(), getActualVariance());	
+		}
 	}
 
 	protected BoundTypeArgumentSource getTypeArgumentSource() {
@@ -153,8 +156,13 @@ public class DeferredTypeParameterHintCollector extends AbstractTypeReferencePai
 					}
 				};
 				LightweightTypeReference lightweightReference = factory.toLightweightReference(constraintReference);
-				if (!recursive[0] && hint.isAssignableFrom(lightweightReference)) {
-					hint = lightweightReference;
+				if (!recursive[0]) {
+					if (hint.isAssignableFrom(lightweightReference)) {
+						hint = lightweightReference;	
+					} else if (hint.isResolved() && !(lightweightReference.getType() instanceof JvmTypeParameter) && !lightweightReference.isAssignableFrom(hint, TypeConformanceComputationArgument.RAW)) {
+						return null;
+					}
+					
 				}
 			}
 		}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/DeferredTypeParameterHintCollector.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/DeferredTypeParameterHintCollector.java
@@ -159,10 +159,9 @@ public class DeferredTypeParameterHintCollector extends AbstractTypeReferencePai
 				if (!recursive[0]) {
 					if (hint.isAssignableFrom(lightweightReference)) {
 						hint = lightweightReference;	
-					} else if (hint.isResolved() && !(lightweightReference.getType() instanceof JvmTypeParameter) && !lightweightReference.isAssignableFrom(hint, TypeConformanceComputationArgument.RAW)) {
+					} else if (hint.isResolved() && !lightweightReference.getRawTypeReference().isAssignableFrom(hint, TypeConformanceComputationArgument.RAW)) {
 						return null;
 					}
-					
 				}
 			}
 		}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/TypeParameterSubstitutor.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/TypeParameterSubstitutor.java
@@ -174,7 +174,7 @@ public abstract class TypeParameterSubstitutor<Visiting> extends TypeReferenceVi
 					result.setLowerBound(lowerBoundSubstitute);
 				}
 			} else {
-				result.setLowerBound(visited);
+				result.setLowerBound(visited.copyInto(result.getOwner()));
 			}
 		} 
 		for(LightweightTypeReference upperBound: reference.getUpperBounds()) {


### PR DESCRIPTION
We didn't handle more involving generics situtations properly, e.g. when type constraints referred to type parameters of another nesting level, e.g `T extends A & B, X extends I<T>` where `I<T>`refers to a generic type with complex type constraints, too. During inference, we do now detect situations where we again compare potential type substitutes even though we had seen those before.
The fix is twofold: We figure during the processing of UnboundTypeReferences in the RawTypeConformanceComputer that we did already process a certain reference. The second piece to the puzzle is that we do not collect substitution hints when we know for sure that they are invalid, e.g. when they do not match the type constraints.

This PR also contains minor cosmetic fixes, e.g. for error messages or the instantiation of TypeConformanceComputationArguments. Tests are in the Xtend repo. PR follows. 