### PR TITLE
[eclipse/xtext-xtend#447] dont issue warnings for raw types inside instanceof

### DIFF
--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/validation/JvmTypeReferencesValidatorTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/validation/JvmTypeReferencesValidatorTest.java
@@ -62,6 +62,16 @@ public class JvmTypeReferencesValidatorTest extends AbstractXbaseTestCase {
 		helper.assertWarning(expression, TypesPackage.Literals.JVM_TYPE_REFERENCE, IssueCodes.RAW_TYPE);
 	}
 	
+	@Test public void testNoTypeArg_instanceof() throws Exception {
+		XExpression expression = expression("{ var Object o = null; o instanceof java.util.Map }");
+		helper.assertNoWarnings(expression, TypesPackage.Literals.JVM_TYPE_REFERENCE, IssueCodes.RAW_TYPE);
+	}
+	
+	@Test public void testNoTypeArg_instanceof_02() throws Exception {
+		XExpression expression = expression("{ var java.util.Map x = null x } instanceof java.util.Map");
+		helper.assertWarning(expression, TypesPackage.Literals.JVM_TYPE_REFERENCE, IssueCodes.RAW_TYPE);
+	}
+	
 	@Test public void testWrongNumberOfTypeArgs_0() throws Exception {
 		XExpression expression = expression("{ val java.util.List<String, String> x = null }");
 		helper.assertError(expression, TypesPackage.Literals.JVM_TYPE_REFERENCE, IssueCodes.INVALID_NUMBER_OF_TYPE_ARGUMENTS);

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/JvmTypeReferencesValidator.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/JvmTypeReferencesValidator.java
@@ -17,6 +17,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.common.types.JvmFormalParameter;
 import org.eclipse.xtext.common.types.JvmGenericType;
 import org.eclipse.xtext.common.types.JvmParameterizedTypeReference;
@@ -31,6 +32,7 @@ import org.eclipse.xtext.common.types.util.Primitives;
 import org.eclipse.xtext.common.types.util.TypeReferences;
 import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
 import org.eclipse.xtext.validation.Check;
+import org.eclipse.xtext.xbase.XInstanceOfExpression;
 import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociations;
 import org.eclipse.xtext.xbase.typesystem.references.CompoundTypeReference;
 import org.eclipse.xtext.xbase.typesystem.references.LightweightTypeReference;
@@ -129,6 +131,9 @@ public class JvmTypeReferencesValidator extends AbstractDeclarativeValidator {
 	}
 
 	protected void warnRawType(JvmType type, JvmParameterizedTypeReference typeRef) {
+		if (typeRef.eContainer() instanceof XInstanceOfExpression) {
+			return;
+		}
 		StringBuilder message = new StringBuilder(64);
 		message.append(type.getSimpleName());
 		message.append(" is a raw type. References to generic type ");


### PR DESCRIPTION
[eclipse/xtext-xtend#447] dont issue warnings for raw types inside instanceof

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>