### PR TITLE
[#262] Made type lookup case sensitive even on windows

### DIFF
--- a/org.eclipse.xtext.common.types.tests/tests/org/eclipse/xtext/common/types/access/impl/BinaryClassFinderTest.java
+++ b/org.eclipse.xtext.common.types.tests/tests/org/eclipse/xtext/common/types/access/impl/BinaryClassFinderTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.common.types.access.impl;
 
+import org.eclipse.xtext.common.types.access.binary.BinaryClass;
 import org.eclipse.xtext.common.types.access.binary.BinaryClassFinder;
 import org.junit.After;
 import org.junit.Assert;
@@ -56,6 +57,27 @@ public class BinaryClassFinderTest extends Assert {
 	
 	@Test public void testObjectArray_02() throws ClassNotFoundException {
 		assertEquals(Object[].class.getName(), classFinder.forName(Object[].class.getName()).getName());
+	}
+	
+	@Test public void testBinaryClassFinder() throws ClassNotFoundException {
+		assertEquals(BinaryClassFinder.class.getName(), classFinder.forName(BinaryClassFinder.class.getName()).getName());
+	}
+	
+	@Test(expected=ClassNotFoundException.class) public void testBinaryClassFinderWrongCasing() throws ClassNotFoundException {
+		classFinder.forName(BinaryClassFinder.class.getName().toUpperCase());
+	}
+	
+	@Test public void testBinaryClassFinderWrongCasingForcedCaseSensitive() throws ClassNotFoundException, NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+		BinaryClass.assumeCaseSensitive((originalValue)->{
+			try {
+				String upperCase = BinaryClassFinder.class.getName().toUpperCase();
+				BinaryClass found = classFinder.forName(upperCase);
+				assertFalse(originalValue);
+				assertEquals(upperCase, found.getName());
+			} catch(ClassNotFoundException e) {
+				assertTrue(originalValue);
+			}
+		});
 	}
 	
 }

--- a/org.eclipse.xtext.common.types.tests/tests/org/eclipse/xtext/common/types/access/impl/BinaryClassFinderTest.java
+++ b/org.eclipse.xtext.common.types.tests/tests/org/eclipse/xtext/common/types/access/impl/BinaryClassFinderTest.java
@@ -60,17 +60,17 @@ public class BinaryClassFinderTest extends Assert {
 	}
 	
 	@Test public void testBinaryClassFinder() throws ClassNotFoundException {
-		assertEquals(BinaryClassFinder.class.getName(), classFinder.forName(BinaryClassFinder.class.getName()).getName());
+		assertEquals(BinaryClassFinderTest.class.getName(), classFinder.forName(BinaryClassFinderTest.class.getName()).getName());
 	}
 	
 	@Test(expected=ClassNotFoundException.class) public void testBinaryClassFinderWrongCasing() throws ClassNotFoundException {
-		classFinder.forName(BinaryClassFinder.class.getName().toUpperCase());
+		classFinder.forName(BinaryClassFinderTest.class.getName().toUpperCase());
 	}
 	
-	@Test public void testBinaryClassFinderWrongCasingForcedCaseSensitive() throws ClassNotFoundException, NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+	@Test public void testBinaryClassFinderWrongCasingForcedCaseSensitive() throws Exception {
 		BinaryClass.assumeCaseSensitive((originalValue)->{
 			try {
-				String upperCase = BinaryClassFinder.class.getName().toUpperCase();
+				String upperCase = BinaryClassFinderTest.class.getName().toUpperCase();
 				BinaryClass found = classFinder.forName(upperCase);
 				assertFalse(originalValue);
 				assertEquals(upperCase, found.getName());

--- a/org.eclipse.xtext.common.types/src/org/eclipse/xtext/common/types/access/binary/BinaryClass.java
+++ b/org.eclipse.xtext.common.types/src/org/eclipse/xtext/common/types/access/binary/BinaryClass.java
@@ -15,6 +15,7 @@ import java.net.URL;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.common.types.access.impl.URIHelperConstants;
+import org.eclipse.xtext.util.IAcceptor;
 
 import com.google.common.base.Strings;
 
@@ -231,7 +232,20 @@ public class BinaryClass {
 		};
 	}
 	
-	private static final boolean IS_CASE_SENSITIVE = isCaseSensitive();
+	private static boolean IS_CASE_SENSITIVE = isCaseSensitive();
+	
+	/*
+	 * Public for testing purpose
+	 */
+	public static void assumeCaseSensitive(IAcceptor<Boolean> r) {
+		boolean oldValue = IS_CASE_SENSITIVE;
+		try {
+			IS_CASE_SENSITIVE = true;
+			r.accept(oldValue);
+		} finally {
+			IS_CASE_SENSITIVE = oldValue;
+		}
+	}
 	
 	private static boolean isCaseSensitive() {
 		String result = System.getProperty("org.eclipse.xtext.common.types.access.binary.BinaryClass.ASSUME_CASE_SENSITIVE", Boolean.toString(inferIsCaseSensitive()));

--- a/org.eclipse.xtext.common.types/src/org/eclipse/xtext/common/types/access/binary/BinaryClass.java
+++ b/org.eclipse.xtext.common.types/src/org/eclipse/xtext/common/types/access/binary/BinaryClass.java
@@ -247,7 +247,7 @@ public class BinaryClass {
 		if (!IS_CASE_SENSITIVE && "file".equals(url.getProtocol())) {
 			try {
 				File file = new File(url.toURI());
-				return file.getCanonicalFile().getName().equals(file.getName());
+				return file.getCanonicalFile().getPath().equals(file.getPath());
 			} catch(IOException|URISyntaxException e) {
 				return false;
 			}

--- a/org.eclipse.xtext.common.types/src/org/eclipse/xtext/common/types/access/binary/BinaryClass.java
+++ b/org.eclipse.xtext.common.types/src/org/eclipse/xtext/common/types/access/binary/BinaryClass.java
@@ -234,6 +234,11 @@ public class BinaryClass {
 	private static final boolean IS_CASE_SENSITIVE = isCaseSensitive();
 	
 	private static boolean isCaseSensitive() {
+		String result = System.getProperty("org.eclipse.xtext.common.types.access.binary.BinaryClass.ASSUME_CASE_SENSITIVE", Boolean.toString(inferIsCaseSensitive()));
+		return Boolean.parseBoolean(result);
+	}
+	
+	private static boolean inferIsCaseSensitive() {
 		try {
 			File tempFile = File.createTempFile("prefix", "");
 			File upperCase = new File(tempFile.getParentFile(), tempFile.getName().toUpperCase());


### PR DESCRIPTION
This appears to be a rather expensive solution for a rare corner case but I'm not sure how to solve this in another way. The file / resource lookup is completely transparent to Java and handled natively by the OS. That's why we need to convert the found name to the canonical name to check if it's the real thing. 