### PR TITLE
https://github.com/eclipse/xtext-eclipse/issues/753

### DIFF
--- a/org.eclipse.xtext.xbase.testing/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.testing/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase;visibility:=reexport,
- org.eclipse.jdt.core;bundle-version="3.6.0",
+ org.eclipse.jdt.core;bundle-version="3.6.0";visibility:=reexport,
  org.junit;bundle-version="4.12.0",
  org.eclipse.xtext.testing,
  org.eclipse.core.runtime


### PR DESCRIPTION
- Ensure that the org.eclipse.xtext.xbase.testing package reexports the
require org.eclipse.jdt.core bundle.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>