### PR TITLE
Fixing typo: 'catched' -> 'caught'

### DIFF
--- a/org.eclipse.xtext.extras.tests/src/org/eclipse/xtext/generator/CompositeGeneratorFragmentTest.java
+++ b/org.eclipse.xtext.extras.tests/src/org/eclipse/xtext/generator/CompositeGeneratorFragmentTest.java
@@ -129,7 +129,7 @@ public class CompositeGeneratorFragmentTest extends Assert {
 			fail("CompositeGeneratorException was not thrown");
 		} catch (CompositeGeneratorException e) {
 			Iterable<Exception> exceptions = e.getExceptions();
-			assertEquals("Two exceptions catched and re thrown", 2, Iterables.size(exceptions));
+			assertEquals("Two exceptions caught and re thrown", 2, Iterables.size(exceptions));
 
 			for (Exception exception : exceptions) {
 				if (exception instanceof WrappedException) {

--- a/org.eclipse.xtext.purexbase.tests/src/org/eclipse/xtext/purexbase/test/CompilerTest.xtend
+++ b/org.eclipse.xtext.purexbase.tests/src/org/eclipse/xtext/purexbase/test/CompilerTest.xtend
@@ -485,7 +485,7 @@ class CompilerTest {
 			/*
 			 * Xbase supports Exception handling using the same syntax as is used 
 			 * in Java. There are two differences:
-			 * 1) Checked exceptions must not be catched in closures.
+			 * 1) Checked exceptions must not be caught in closures.
 			 * 2) Try-catch is an expression and can therefore be used in a deeply 
 			 *    nested way 
 			 */

--- a/org.eclipse.xtext.purexbase.tests/xtend-gen/org/eclipse/xtext/purexbase/test/CompilerTest.java
+++ b/org.eclipse.xtext.purexbase.tests/xtend-gen/org/eclipse/xtext/purexbase/test/CompilerTest.java
@@ -1122,7 +1122,7 @@ public class CompilerTest {
       _builder.append("* in Java. There are two differences:");
       _builder.newLine();
       _builder.append(" ");
-      _builder.append("* 1) Checked exceptions must not be catched in closures.");
+      _builder.append("* 1) Checked exceptions must not be caught in closures.");
       _builder.newLine();
       _builder.append(" ");
       _builder.append("* 2) Try-catch is an expression and can therefore be used in a deeply ");


### PR DESCRIPTION
Signed-off-by: Tamas Miklossy <miklossy@itemis.de>