### PR TITLE
[eclipse/xtext-xtend#508] Fixed Type Usage collector for JvmSynonymTypeReferences

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/TypeUsageCollector.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/TypeUsageCollector.java
@@ -23,6 +23,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.common.types.JvmAnnotationType;
 import org.eclipse.xtext.common.types.JvmArrayType;
+import org.eclipse.xtext.common.types.JvmCompoundTypeReference;
 import org.eclipse.xtext.common.types.JvmDeclaredType;
 import org.eclipse.xtext.common.types.JvmEnumerationLiteral;
 import org.eclipse.xtext.common.types.JvmFeature;
@@ -32,6 +33,7 @@ import org.eclipse.xtext.common.types.JvmIdentifiableElement;
 import org.eclipse.xtext.common.types.JvmMember;
 import org.eclipse.xtext.common.types.JvmOperation;
 import org.eclipse.xtext.common.types.JvmParameterizedTypeReference;
+import org.eclipse.xtext.common.types.JvmSynonymTypeReference;
 import org.eclipse.xtext.common.types.JvmType;
 import org.eclipse.xtext.common.types.JvmTypeReference;
 import org.eclipse.xtext.common.types.JvmWildcardTypeReference;
@@ -380,6 +382,7 @@ public class TypeUsageCollector {
 		if (ref instanceof XFunctionTypeRef 
 		 || ref instanceof JvmWildcardTypeReference
 		 || ref instanceof JvmGenericArrayTypeReference
+		 || ref instanceof JvmCompoundTypeReference
 		 || (ref.eContainer() instanceof XFunctionTypeRef 
 				 && ref.eContainmentFeature() == JVM_SPECIALIZED_TYPE_REFERENCE__EQUIVALENT)
 		 || NodeModelUtils.findActualNodeFor(ref) == null) 


### PR DESCRIPTION
[eclipse/xtext-xtend#508] Fixed Type Usage collector for JvmSynonymTypeReferences

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>