### PR TITLE
[eclipse/xtext-extras#281] made XtextResource.getEObject(Fragment,Triple) better customizable for BatchLinkableResources

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResource.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResource.java
@@ -116,7 +116,7 @@ public class BatchLinkableResource extends DerivedStateAwareResource implements 
 								log.error("Don't resolve expressions during indexing!", new IllegalStateException("Resource URI : "+getURI()+", fragment : "+uriFragment));
 							return batchLinkingService.resolveBatched(triple.getFirst(), triple.getSecond(), uriFragment);
 						}
-						return super.getEObject(uriFragment, triple);
+						return getEObject(uriFragment, triple);
 					} else {
 						return null;
 					}


### PR DESCRIPTION
[eclipse/xtext-extras#281] made XtextResource.getEObject(Fragment,Triple) better customizable for BatchLinkableResources

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>