### PR TITLE
Fixed extension name computation of getters and is-methods in the SerializerScopeProvider

### DIFF
--- a/org.eclipse.xtext.xbase.testing/src/org/eclipse/xtext/xbase/testing/evaluation/AbstractXbaseEvaluationTest.java
+++ b/org.eclipse.xtext.xbase.testing/src/org/eclipse/xtext/xbase/testing/evaluation/AbstractXbaseEvaluationTest.java
@@ -4990,16 +4990,16 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 		}
 	}
 	
-	@Test 
+	@Test
 	public void testNullSaveLazyEvaluation1() throws Exception {
 		assertEvaluatesTo(0, "{ var x = 0; (null as String)?.substring(x = 1); return x; }");
 	}
 	
-	@Test 
+	@Test
 	public void testNullSaveLazyEvaluation2() throws Exception {
 		assertEvaluatesTo(0, "{ val x = <String>newArrayList; var c = [|x += 'x';1]; (null as String)?.substring(c.apply); return x.size; }");
 	}
-	
+
 	/**
 	 * @param expression the input that should be executed 
 	 */

--- a/org.eclipse.xtext.xbase.testing/testdata/testdata/ShorthandNames.java
+++ b/org.eclipse.xtext.xbase.testing/testdata/testdata/ShorthandNames.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package testdata;
+
+/**
+ * @author dietrich - Initial contribution and API
+ */
+public class ShorthandNames {
+
+	private int fake;
+	private int UPPER;
+	private int lower;
+	private int camelCase;
+	private int UPper;
+	private int x;
+
+	private boolean UPPERBOOL;
+	private boolean lowerbool;
+	private boolean camelCaseBool;
+	private boolean UPperBool;
+
+	public int get() {
+		return fake;
+	}
+	public void set(int fake) {
+		this.fake = fake;
+	}
+	public boolean is() {
+		return true;
+	}
+	public int getUPPER() {
+		return UPPER;
+	}
+	public void setUPPER(int uPPER) {
+		UPPER = uPPER;
+	}
+	public int getLower() {
+		return lower;
+	}
+	public void setLower(int lower) {
+		this.lower = lower;
+	}
+	public int getCamelCase() {
+		return camelCase;
+	}
+	public void setCamelCase(int cameCase) {
+		this.camelCase = cameCase;
+	}
+	public int getUPper() {
+		return UPper;
+	}
+	public void setUPper(int UPper) {
+		this.UPper = UPper;
+	}
+	public int getX() {
+		return x;
+	}
+	public void setX(int x) {
+		this.x = x;
+	}
+	public boolean isUPPERBOOL() {
+		return UPPERBOOL;
+	}
+	public void setUPPERBOOL(boolean uPPERBOOL) {
+		UPPERBOOL = uPPERBOOL;
+	}
+	public boolean isLowerbool() {
+		return lowerbool;
+	}
+	public void setLowerbool(boolean lowerbool) {
+		this.lowerbool = lowerbool;
+	}
+	public boolean isCamelCaseBool() {
+		return camelCaseBool;
+	}
+	public void setCamelCaseBool(boolean camelCaseBool) {
+		this.camelCaseBool = camelCaseBool;
+	}
+	public boolean isUPperBool() {
+		return UPperBool;
+	}
+	public void setUPperBool(boolean UPperBool) {
+		this.UPperBool = UPperBool;
+	}
+}

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/junit/evaluation/AbstractXbaseEvaluationTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/junit/evaluation/AbstractXbaseEvaluationTest.java
@@ -5077,6 +5077,61 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	@Test public void testBug485032_03() throws Exception {
 		assertEvaluatesTo(-1, "{var x = testdata.AssertJLikeAssertions.assertThat(1 as Integer).compareTo(2); return x;}");
 	}
+
+	@Test
+	public void testShorthandLowerbool() throws Exception {
+		assertEvaluatesTo(true, "(new testdata.ShorthandNames() => [ lowerbool = true ]).lowerbool");
+	}
+
+	@Test
+	public void testShorthandLower() throws Exception {
+		assertEvaluatesTo(1, "(new testdata.ShorthandNames() => [ lower = 1 ]).lower");
+	}
+
+	@Test
+	public void testShorthandCamelCaseBool() throws Exception {
+		assertEvaluatesTo(true, "(new testdata.ShorthandNames() => [ camelCaseBool = true ]).camelCaseBool");
+	}
+
+	@Test
+	public void testShorthandCamelCase() throws Exception {
+		assertEvaluatesTo(1, "(new testdata.ShorthandNames() => [ camelCase = 1 ]).camelCase");
+	}
+
+	@Test
+	public void testShorthandUpperbool() throws Exception {
+		assertEvaluatesTo(true, "(new testdata.ShorthandNames() => [ UPPERBOOL = true ]).UPPERBOOL");
+	}
+
+	@Test
+	public void testShorthandUpper() throws Exception {
+		assertEvaluatesTo(1, "(new testdata.ShorthandNames() => [ UPPER = 1 ]).UPPER");
+	}
+
+	@Test
+	public void testShorthandJustGetAndSet() throws Exception {
+		assertEvaluatesTo(1, "(new testdata.ShorthandNames() => [ set = 1 ]).get");
+	}
+
+	@Test
+	public void testShorthandJustIs() throws Exception {
+		assertEvaluatesTo(true, "(new testdata.ShorthandNames()).is");
+	}
+
+	@Test
+	public void testShorthandFirstAndSecondUpper() throws Exception {
+		assertEvaluatesTo(1, "(new testdata.ShorthandNames() => [ UPper = 1 ]).UPper");
+	}
+
+	@Test
+	public void testShorthandFirstAndSecondUpperBool() throws Exception {
+		assertEvaluatesTo(true, "(new testdata.ShorthandNames() => [ UPperBool = true ]).UPperBool");
+	}
+
+	@Test
+	public void testShorthandOneLetter() throws Exception {
+		assertEvaluatesTo(1, "(new testdata.ShorthandNames() => [ x = 1 ]).x");
+	}
 	
 	/**
 	 * @param expression the input that should be executed 

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/scoping/batch/AbstractSessionBasedScope.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/scoping/batch/AbstractSessionBasedScope.java
@@ -110,7 +110,7 @@ public abstract class AbstractSessionBasedScope extends AbstractScope {
 	}
 	
 	/**
-	 * Returns the name as a property name, e.g. a prefix {@code get}, {@code is} or {@code set} 
+	 * Returns the name as a property name, e.g. a prefix {@code get}, {@code is} or {@code set}
 	 * can be used with the result of this method.
 	 * If the given name is invalid, the result is <code>null</code>.
 	 */
@@ -145,7 +145,7 @@ public abstract class AbstractSessionBasedScope extends AbstractScope {
 		// length 0 is invalid
 		return null;
 	}
-	
+
 	/**
 	 * Clients may override to reject certain descriptions from the result. All subtypes of {@link AbstractSessionBasedScope}
 	 * in the framework code will delegate to this method to accumulate descriptions in a list.

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/util/PropertyUtil.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/util/PropertyUtil.xtend
@@ -12,6 +12,8 @@ import org.eclipse.xtext.common.types.JvmOperation
 
 import static extension java.beans.Introspector.*
 import static extension java.lang.Character.*
+import java.util.Locale
+import org.eclipse.xtext.util.Strings
 
 /**
  * @author kosyakov - Initial contribution and API
@@ -48,4 +50,42 @@ class PropertyUtil {
 		methodName.length > prefixLength && methodName.startsWith(prefix) && methodName.charAt(prefixLength).upperCase
 	}
 
+	/**
+	 * Returns the shorthand name for a function
+	 * e.g. URI for getURI; uri for setUri; null for getuRI; enum for isEnum
+	 * If the given name is invalid, the result is <code>null</code>.
+	 * 
+	 * @param fullName the fullName of the function we're trying to shorthand (including 'get' or 'is')
+	 * 
+	 * @since 2.15
+	 */
+	/* @Nullable */
+	def static String tryGetShorthandName(String fullName) {
+		val name = if (fullName.startsWith("get") || fullName.startsWith("set")) {
+				fullName.substring(3)
+			} else if (fullName.startsWith("is")) {
+				fullName.substring(2)
+			} else {
+				return null
+			}
+
+		if (name.length() == 1) { // e.g. Point.getX()
+			return name.toLowerCase(Locale.ENGLISH);
+		} else if (name.length() > 1) {
+			if (Character.isUpperCase(name.charAt(1))) {
+				// if second char is uppercase, the name itself is the shorthand
+				// URI is the property name for getURI
+				if (Character.isUpperCase(name.charAt(0))) {
+					return name;
+				}
+				// if the first character is not upper case, but the second is, then there is no shorthand
+				// e.g. geteObject has no shorthand
+				return null;
+			} else {
+				return Strings.toFirstLower(name);
+			}
+		}
+		// length 0 is invalid
+		return null;
+	}
 }	

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/util/PropertyUtil.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/util/PropertyUtil.java
@@ -8,8 +8,10 @@
 package org.eclipse.xtext.xbase.util;
 
 import java.beans.Introspector;
+import java.util.Locale;
 import org.eclipse.xtext.common.types.JvmFeature;
 import org.eclipse.xtext.common.types.JvmOperation;
+import org.eclipse.xtext.util.Strings;
 
 /**
  * @author kosyakov - Initial contribution and API
@@ -65,5 +67,46 @@ public class PropertyUtil {
   
   protected static boolean startsWithPrefix(final String methodName, final String prefix, final int prefixLength) {
     return (((methodName.length() > prefixLength) && methodName.startsWith(prefix)) && Character.isUpperCase(methodName.charAt(prefixLength)));
+  }
+  
+  /**
+   * @Nullable
+   */
+  public static String tryGetShorthandName(final String fullName) {
+    String _xifexpression = null;
+    if ((fullName.startsWith("get") || fullName.startsWith("set"))) {
+      _xifexpression = fullName.substring(3);
+    } else {
+      String _xifexpression_1 = null;
+      boolean _startsWith = fullName.startsWith("is");
+      if (_startsWith) {
+        _xifexpression_1 = fullName.substring(2);
+      } else {
+        return null;
+      }
+      _xifexpression = _xifexpression_1;
+    }
+    final String name = _xifexpression;
+    int _length = name.length();
+    boolean _equals = (_length == 1);
+    if (_equals) {
+      return name.toLowerCase(Locale.ENGLISH);
+    } else {
+      int _length_1 = name.length();
+      boolean _greaterThan = (_length_1 > 1);
+      if (_greaterThan) {
+        boolean _isUpperCase = Character.isUpperCase(name.charAt(1));
+        if (_isUpperCase) {
+          boolean _isUpperCase_1 = Character.isUpperCase(name.charAt(0));
+          if (_isUpperCase_1) {
+            return name;
+          }
+          return null;
+        } else {
+          return Strings.toFirstLower(name);
+        }
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
The `SerializerScopeProvider` always calculates the name for extension methods by throwing away the `get` or `is` at the start of the function and then making the first remaining character lowercase. This runs into trouble for methods such as `getURI`. That method's extension name is `URI` not `uRI`.