### PR TITLE
[eclipse/xtext-extras#168] fixed deprecated gradle api usage for longrunning tests

### DIFF
--- a/gradle/longrunning-tests.gradle
+++ b/gradle/longrunning-tests.gradle
@@ -45,7 +45,7 @@ sourcesJar {
 task longrunningTest(type: Test) {
 	group = 'Verification'
 	description = 'Runs the long-running unit tests.'
-	testClassesDir = sourceSets.longrunning.output.classesDir
+	testClassesDirs = sourceSets.longrunning.output.classesDirs
 	classpath = sourceSets.longrunning.runtimeClasspath
 }
 


### PR DESCRIPTION
[eclipse/xtext-extras#168] fixed deprecated gradle api usage for longrunning tests

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>