### PR TITLE
[https://github.com/eclipse/xtext-xtend/issues/554]

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -341,10 +341,10 @@ class JvmModelGenerator implements IGenerator {
 	
 	def dispatch generateModifier(JvmField it, ITreeAppendable appendable, GeneratorConfig config) {
 		generateVisibilityModifier(it, appendable)
-		if (isFinal)
-			appendable.append("final ")
 		if (isStatic)
 			appendable.append("static ")
+		if (isFinal)
+			appendable.append("final ")
 		if (isTransient)
 			appendable.append("transient ")
 		if (isVolatile)

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -540,13 +540,13 @@ public class JvmModelGenerator implements IGenerator {
     ITreeAppendable _xblockexpression = null;
     {
       this.generateVisibilityModifier(it, appendable);
-      boolean _isFinal = it.isFinal();
-      if (_isFinal) {
-        appendable.append("final ");
-      }
       boolean _isStatic = it.isStatic();
       if (_isStatic) {
         appendable.append("static ");
+      }
+      boolean _isFinal = it.isFinal();
+      if (_isFinal) {
+        appendable.append("final ");
       }
       boolean _isTransient = it.isTransient();
       if (_isTransient) {


### PR DESCRIPTION
Ensure static and final modifiers generated in the right order.

- Modify the JvmModelGenerator to generate the static and the final
modifiers in the right order (corresponding to the java language
specification) 'static final' instead of 'final static'.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>