### PR TITLE
Change the visibility of CandidateComparisonResult to public.

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/CandidateCompareResult.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/CandidateCompareResult.java
@@ -10,7 +10,7 @@ package org.eclipse.xtext.xbase.typesystem.internal;
 /**
  * The result of the comparison of two linking candidates. 
  */
-enum CandidateCompareResult {
+public enum CandidateCompareResult {
 	/**
 	 * Indicates that the current candidate is a better match than the other one.
 	 */


### PR DESCRIPTION
It is impossible for the subtypes of `AbstractPendingLinkingCandidate` to call the `compareTo` function because the visibility of `CandidateComparisonResult` is package.
The visiblity should be changed to `public` for enabling the subtypes' functions to call `compareTo`.

Signed-off-by: Stéphane Galland <galland@arakhne.org>