### PR TITLE
eclipse-xtext/xtext#1168: Re-export jdt.core (accidently removed).

### DIFF
--- a/org.eclipse.xtext.xbase.testing/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.testing/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase;visibility:=reexport,
- org.eclipse.jdt.core;bundle-version="3.13.102",
+ org.eclipse.jdt.core;bundle-version="3.13.102";visibility:=reexport,
  org.junit;bundle-version="4.12.0",
  org.eclipse.xtext.testing,
  org.eclipse.core.runtime;bundle-version="3.13.0"


### PR DESCRIPTION
Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>