### PR TITLE
[#346] Refactoring the JavaKeywords.isJavaKeyword(String s) method.

### DIFF
--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/compiler/JavaKeywordTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/compiler/JavaKeywordTest.java
@@ -1,11 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *******************************************************************************/
 package org.eclipse.xtext.xbase.tests.compiler;
+
+import java.util.Arrays;
+import java.util.List;
 
 import org.eclipse.xtext.xbase.compiler.JavaKeywords;
 import org.eclipse.xtext.xbase.tests.AbstractXbaseTestCase;
@@ -18,23 +21,67 @@ import com.google.inject.Inject;
  */
 public class JavaKeywordTest extends AbstractXbaseTestCase {
 
-	@Inject 
+	@Inject
 	private JavaKeywords javaKeywords;
 	
-	@Test public void testAssert() {
-		assertTrue(javaKeywords.isJavaKeyword("assert"));
-	}
+	private final static List<String> JAVA_KEYWORDS = Arrays.asList(
+		"abstract",
+		"assert", // added in 1.4
+		"boolean",
+		"break",
+		"byte",
+		"case",
+		"catch",
+		"char",
+		"class",
+		"const", // not used
+		"continue",
+		"default",
+		"do",
+		"double",
+		"else",
+		"enum", // added in 5.0
+		"extends",
+		"false",
+		"final",
+		"finally",
+		"float",
+		"for",
+		"goto", // not used
+		"if",
+		"implements",
+		"import",
+		"instanceof",
+		"int",
+		"interface",
+		"long",
+		"native",
+		"new",
+		"null",
+		"package",
+		"private",
+		"protected",
+		"public",
+		"return",
+		"short",
+		"static",
+		"strictfp", // added in 1.2
+		"super",
+		"switch",
+		"synchronized",
+		"this",
+		"throw",
+		"throws",
+		"transient",
+		"true",
+		"try",
+		"void",
+		"volatile",
+		"while");
 
-	@Test public void testNull() {
-		assertTrue(javaKeywords.isJavaKeyword("null"));
+	@Test public void testJavaKeyword() {
+		for(String javaKeyword : JAVA_KEYWORDS) {
+			assertTrue(javaKeywords.isJavaKeyword(javaKeyword));
+		}
 	}
-	
-	@Test public void testTrue() {
-		assertTrue(javaKeywords.isJavaKeyword("true"));
-	}
-
-	@Test public void testFalse() {
-		assertTrue(javaKeywords.isJavaKeyword("false"));
-	}
-
 }

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JavaKeywords.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JavaKeywords.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,70 +7,13 @@
  *******************************************************************************/
 package org.eclipse.xtext.xbase.compiler;
 
-import java.util.Set;
-
-import com.google.common.collect.Sets;
+import javax.lang.model.SourceVersion;
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
 public class JavaKeywords {
 	public boolean isJavaKeyword(String s) {
-		return JAVA_KEYWORDS.contains(s);
+		return SourceVersion.isKeyword(s);
 	}
-	
-	private final static Set<String> JAVA_KEYWORDS= Sets.newHashSet(
-			"abstract" ,
-	        "assert" , // added in 1.4
-	        "boolean" ,
-	        "break" ,
-	        "byte" ,
-	        "case" ,
-	        "catch" ,
-	        "char" ,
-	        "class" ,
-	        "const" , // not used
-	        "continue" ,
-	        "default" ,
-	        "do" ,
-	        "double" ,
-	        "else" ,
-	        "enum" , // added in 5.0
-	        "extends" ,
-	        "false" ,
-	        "final" ,
-	        "finally" ,
-	        "float" ,
-	        "for" ,
-	        "goto" , // not used
-	        "if" ,
-	        "implements" ,
-	        "import" ,
-	        "instanceof" ,
-	        "int" ,
-	        "interface" ,
-	        "long" ,
-	        "native" ,
-	        "new" ,
-	        "null" ,
-	        "package" ,
-	        "private" ,
-	        "protected" ,
-	        "public" ,
-	        "return" ,
-	        "short" ,
-	        "static" ,
-	        "strictfp" , // added in 1.2
-	        "super" ,
-	        "switch" ,
-	        "synchronized" ,
-	        "this" ,
-	        "throw" ,
-	        "throws" ,
-	        "transient" ,
-	        "true" ,
-	        "try" ,
-	        "void" ,
-	        "volatile" ,
-	        "while");
 }


### PR DESCRIPTION
- Delegate to javax.lang.model.SourceVersion.isKeyword(String s) method.
- Implement additional JavaKeywordTest test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>