### PR TITLE
[eclipse/xtext#1182] added support for java 11 as target

### DIFF
--- a/org.eclipse.xtext.java.tests/build.gradle
+++ b/org.eclipse.xtext.java.tests/build.gradle
@@ -11,5 +11,5 @@ configurations {
 }
 
 test {
-	maxHeapSize = "768m"
+	maxHeapSize = "1G"
 }


### PR DESCRIPTION
[eclipse/xtext#1182] added support for java 11 as target
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>