### PR TITLE
[eclipse/xtext#1283] update to MWE 2.10

### DIFF
--- a/releng/releng-target/xtext-extras.target.target
+++ b/releng/releng-target/xtext-extras.target.target
@@ -7,7 +7,7 @@
 			<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/modeling/emft/mwe/updates/milestones/S201901281525"/>
+			<repository location="http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.10.0"/>
 			<unit id="org.eclipse.emf.mwe2.language.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">


### PR DESCRIPTION
[eclipse/xtext#1283] update to MWE 2.10
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>

do not merge before mwe 2.10.0 final is out