### PR TITLE
[eclipse/xtext#1404] Bump Xtext-Gradle-Plugin to latest (2.0.4)

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -8,6 +8,6 @@ ext.versions = [
 	'xtext': version,
 	'xtext_bootstrap': '2.17.0.M2',
 	'gradle_plugins': '0.1.0',
-	'xtext_gradle_plugin': '2.0.2',
+	'xtext_gradle_plugin': '2.0.4',
 	'dependency_management_plugin' : '1.0.6.RELEASE'
 ]


### PR DESCRIPTION
[eclipse/xtext#1404] Bump Xtext-Gradle-Plugin to latest (2.0.4)
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>