### PR TITLE
[eclipse/xtext#1309] Provide Jenkinsfile for Eclipse CBI

### DIFF
--- a/1-gradle-build.sh
+++ b/1-gradle-build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+if [ -z "$JENKINS_URL" ]; then
+  # if not set in environment use default
+  JENKINS_URL=https://ci.eclipse.org/xtext/
+fi
+
+./gradlew \
+  clean cleanGenerateXtext build createLocalMavenRepo \
+  -PuseJenkinsSnapshots=true \
+  -PJENKINS_URL=$JENKINS_URL \
+  -PcompileXtend=true \
+  -PignoreTestFailures=true \
+  --refresh-dependencies \
+  --continue \
+  $@

--- a/2-maven-build.sh
+++ b/2-maven-build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+if [ -z "$JENKINS_URL" ]; then
+  # if not set in environment use default
+  JENKINS_URL=https://ci.eclipse.org/xtext/
+fi
+
+mvn \
+  -f releng \
+  --batch-mode \
+  --update-snapshots \
+  -Dmaven.repo.local=.m2/repository \
+  -DJENKINS_URL=$JENKINS_URL \
+  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+  $@

--- a/3-gradle-longrunning-tests.sh
+++ b/3-gradle-longrunning-tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+if [ -z "$JENKINS_URL" ]; then
+  # if not set in environment use default
+  JENKINS_URL=https://ci.eclipse.org/xtext/
+fi
+
+./gradlew \
+  longrunningTest \
+  -PuseJenkinsSnapshots=true \
+  -PJENKINS_URL=$JENKINS_URL \
+  -PignoreTestFailures=true \
+  $@

--- a/CBI.Jenkinsfile
+++ b/CBI.Jenkinsfile
@@ -1,0 +1,81 @@
+pipeline {
+  agent any
+
+  options {
+    buildDiscarder(logRotator(numToKeepStr:'15'))
+    disableConcurrentBuilds()
+  }
+
+  tools {
+    // see https://wiki.eclipse.org/Jenkins#Jenkins_configuration_and_tools_.28clustered_infra.29
+    maven 'apache-maven-latest'
+    jdk 'oracle-jdk8-latest'
+  }
+  
+  // https://jenkins.io/doc/book/pipeline/syntax/#triggers
+  triggers {
+    pollSCM('H/5 * * * *')
+  }
+  
+  stages {
+    stage('Checkout') {
+      steps {
+        checkout scm
+      }
+    }
+
+    stage('Gradle Build') {
+      steps {
+        sh './1-gradle-build.sh'
+        step([$class: 'JUnitResultArchiver', testResults: '**/build/test-results/test/*.xml'])
+      }
+    }
+    
+    stage('Maven Build & Test') {
+      parallel {
+        stage('Maven Build') {
+          steps {
+            sh './2-maven-build.sh'
+          }
+        }
+  
+        stage('Long Running Tests') {
+          steps {
+            sh './3-gradle-longrunning-tests.sh'
+            step([$class: 'JUnitResultArchiver', testResults: '**/build/test-results/test/*.xml'])
+          }
+        }
+      }
+    }
+  }
+
+  post {
+    success {
+      archiveArtifacts artifacts: 'build/**'
+    }
+    changed {
+      script {
+        def envName = ''
+        if (env.JENKINS_URL.contains('ci.eclipse.org/xtext')) {
+          envName = ' (JIPP)'
+        } else if (env.JENKINS_URL.contains('jenkins.eclipse.org/xtext')) {
+          envName = ' (CBI)'
+        } else if (env.JENKINS_URL.contains('typefox.io')) {
+          envName = ' (TF)'
+        }
+        
+        def curResult = currentBuild.currentResult
+        def color = '#00FF00'
+        if (curResult == 'SUCCESS' && currentBuild.previousBuild != null) {
+          curResult = 'FIXED'
+        } else if (curResult == 'UNSTABLE') {
+          color = '#FFFF00'
+        } else if (curResult == 'FAILURE') {
+          color = '#FF0000'
+        }
+        
+        slackSend message: "${curResult}: <${env.BUILD_URL}|${env.JOB_NAME}#${env.BUILD_NUMBER}${envName}>", botUser: true, channel: 'xtext-builds', color: "${color}"
+      }
+    }
+  }
+}

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -219,6 +219,7 @@
 	</modules>
 
 	<build>
+		<defaultGoal>install</defaultGoal>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>


### PR DESCRIPTION
- externalized build steps into shell scripts for convenient local usage
- added Slack notifications
- configure Maven default goal
- parallelize Maven build and long-running tests

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>