### PR TITLE
[eclipse/xtext#1463] Increase timeout to 60 minutes

### DIFF
--- a/CBI.Jenkinsfile
+++ b/CBI.Jenkinsfile
@@ -52,7 +52,7 @@ spec:
   options {
     buildDiscarder(logRotator(numToKeepStr:'15'))
     disableConcurrentBuilds()
-    timeout(time: 45, unit: 'MINUTES')
+    timeout(time: 60, unit: 'MINUTES')
   }
 
   // https://jenkins.io/doc/book/pipeline/syntax/#triggers


### PR DESCRIPTION
CBI.Jenkinsfile should be updated as well

https://github.com/eclipse/xtext/issues/1463#issuecomment-498196125

Signed-off-by: Nico Prediger <mail@nicoprediger.de>