### PR TITLE
update to guava 27.1

### DIFF
--- a/org.eclipse.xtext.common.types.tests/tests/org/eclipse/xtext/common/types/access/impl/AbstractTypeProviderTest.java
+++ b/org.eclipse.xtext.common.types.tests/tests/org/eclipse/xtext/common/types/access/impl/AbstractTypeProviderTest.java
@@ -3544,10 +3544,7 @@ public abstract class AbstractTypeProviderTest extends Assert {
 				.getOnlyElement(type.findAllFeaturesByName("containsValue"));
 		assertNotNull(containsValue);
 		JvmFormalParameter firstParam = containsValue.getParameters().get(0);
-		assertEquals(1, firstParam.getAnnotations().size());
-		JvmAnnotationReference annotationReference = firstParam.getAnnotations().get(0);
-		JvmAnnotationType annotationType = annotationReference.getAnnotation();
-		assertEquals("java:/Objects/javax.annotation.Nullable", EcoreUtil.getURI(annotationType).trimFragment().toString());
+		assertEquals(0, firstParam.getAnnotations().size());
 	}
 
 	@Test

--- a/org.eclipse.xtext.common.types.tests/tests/org/eclipse/xtext/common/types/access/impl/ClasspathTypeProviderTest.java
+++ b/org.eclipse.xtext.common.types.tests/tests/org/eclipse/xtext/common/types/access/impl/ClasspathTypeProviderTest.java
@@ -291,10 +291,7 @@ public class ClasspathTypeProviderTest extends AbstractTypeProviderTest {
 		JvmOperation containsValue = (JvmOperation) Iterables.getOnlyElement(type.findAllFeaturesByName("containsValue"));
 		assertNotNull(containsValue);
 		JvmFormalParameter firstParam = containsValue.getParameters().get(0);
-		assertEquals(1, firstParam.getAnnotations().size());
-		JvmAnnotationReference annotationReference = firstParam.getAnnotations().get(0);
-		JvmAnnotationType annotationType = annotationReference.getAnnotation();
-		assertEquals("java:/Objects/javax.annotation.Nullable", EcoreUtil.getURI(annotationType).trimFragment().toString());
+		assertEquals(0, firstParam.getAnnotations().size());
 	}
 	
 	@Override

--- a/org.eclipse.xtext.common.types/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.common.types/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle:
  org.eclipse.emf.mwe2.lib;bundle-version="2.9.1";resolution:=optional;x-installation:=greedy,
  org.objectweb.asm;bundle-version="[7.1.0,7.2.0)",
  org.eclipse.xtend.lib,
- com.google.guava;bundle-version="[21.0.0,22.0.0)"
+ com.google.guava;bundle-version="[27.1.0,28.0.0)"
 Import-Package: org.apache.commons.logging;version="1.0.4";resolution:=optional,
  org.apache.log4j;version="1.2.15"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.xtext.java.tests/src/org/eclipse/xtext/java/tests/ReusedTypeProviderTest.xtend
+++ b/org.eclipse.xtext.java.tests/src/org/eclipse/xtext/java/tests/ReusedTypeProviderTest.xtend
@@ -105,9 +105,7 @@ class ReusedTypeProviderTest extends AbstractTypeProviderTest {
 		var JvmGenericType type=getTypeProvider().findTypeByName(typeName) as JvmGenericType 
 		var JvmOperation containsValue=Iterables.getOnlyElement(type.findAllFeaturesByName("containsValue")) as JvmOperation 
 		assertNotNull(containsValue) var JvmFormalParameter firstParam=containsValue.getParameters().get(0) 
-		assertEquals(1, firstParam.getAnnotations().size()) var JvmAnnotationReference annotationReference=firstParam.getAnnotations().get(0) 
-		var JvmAnnotationType annotationType=annotationReference.getAnnotation() 
-		assertTrue(annotationType.eIsProxy()) assertEquals("java:/Objects/javax.annotation.Nullable", EcoreUtil.getURI(annotationType).trimFragment().toString()) 
+		assertEquals(0, firstParam.getAnnotations().size())
 	}
 	
 	@Test

--- a/org.eclipse.xtext.java.tests/xtend-gen/org/eclipse/xtext/java/tests/ReusedTypeProviderTest.java
+++ b/org.eclipse.xtext.java.tests/xtend-gen/org/eclipse/xtext/java/tests/ReusedTypeProviderTest.java
@@ -12,13 +12,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.build.BuildRequest;
 import org.eclipse.xtext.build.IncrementalBuilder;
 import org.eclipse.xtext.build.IndexState;
 import org.eclipse.xtext.build.Source2GeneratedMapping;
-import org.eclipse.xtext.common.types.JvmAnnotationReference;
-import org.eclipse.xtext.common.types.JvmAnnotationType;
 import org.eclipse.xtext.common.types.JvmFeature;
 import org.eclipse.xtext.common.types.JvmFormalParameter;
 import org.eclipse.xtext.common.types.JvmGenericType;
@@ -151,11 +148,7 @@ public class ReusedTypeProviderTest extends AbstractTypeProviderTest {
     JvmOperation containsValue = ((JvmOperation) _onlyElement);
     Assert.assertNotNull(containsValue);
     JvmFormalParameter firstParam = containsValue.getParameters().get(0);
-    Assert.assertEquals(1, firstParam.getAnnotations().size());
-    JvmAnnotationReference annotationReference = firstParam.getAnnotations().get(0);
-    JvmAnnotationType annotationType = annotationReference.getAnnotation();
-    Assert.assertTrue(annotationType.eIsProxy());
-    Assert.assertEquals("java:/Objects/javax.annotation.Nullable", EcoreUtil.getURI(annotationType).trimFragment().toString());
+    Assert.assertEquals(0, firstParam.getAnnotations().size());
   }
   
   @Test

--- a/releng/releng-target/xtext-extras.target.target
+++ b/releng/releng-target/xtext-extras.target.target
@@ -17,6 +17,7 @@
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
 			<unit id="org.junit" version="0.0.0"/>
 			<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
+			<unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
Fixes eclipse/xtext#1398 and eclipse/xtext-lib#111

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>