### PR TITLE
[eclipse/xtext#1481] Delete org/eclipse/[xtext|xtend] from local .m2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,8 @@ pipeline {
     stage('Checkout') {
       steps {
         checkout scm
+        dir('.m2/repository/org/eclipse/xtext') { deleteDir() }
+        dir('.m2/repository/org/eclipse/xtend') { deleteDir() }
       }
     }
 


### PR DESCRIPTION
Signed-off-by: Nico Prediger <mail@nicoprediger.de>