### PR TITLE
[eclipse/xtext#1431] Enhance container support

### DIFF
--- a/1-gradle-build.sh
+++ b/1-gradle-build.sh
@@ -4,6 +4,10 @@ if [ -z "$JENKINS_URL" ]; then
   JENKINS_URL=https://ci.eclipse.org/xtext/
 fi
 
+if [ -f "/.dockerenv" ]; then
+  export GRADLE_OPTS="-Dorg.gradle.daemon=false"
+fi
+
 ./gradlew \
   clean cleanGenerateXtext build createLocalMavenRepo \
   -PuseJenkinsSnapshots=true \

--- a/3-gradle-longrunning-tests.sh
+++ b/3-gradle-longrunning-tests.sh
@@ -4,6 +4,10 @@ if [ -z "$JENKINS_URL" ]; then
   JENKINS_URL=https://ci.eclipse.org/xtext/
 fi
 
+if [ -f "/.dockerenv" ]; then
+  export GRADLE_OPTS="-Dorg.gradle.daemon=false"
+fi
+
 ./gradlew \
   longrunningTest \
   -PuseJenkinsSnapshots=true \

--- a/CBI.Jenkinsfile
+++ b/CBI.Jenkinsfile
@@ -20,10 +20,8 @@ spec:
     resources:
       limits:
         memory: "2Gi"
-        cpu: "1"
       requests:
         memory: "2Gi"
-        cpu: "1"
     volumeMounts:
     - name: settings-xml
       mountPath: /home/jenkins/.m2/settings.xml


### PR DESCRIPTION
Disable Gradle daemon, since a new container for each build is
spawned and the daemon can't be reused anyway.

Remove CPU resource constraint, since default is sufficient.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>