### PR TITLE
[eclipse/xtext#1500] Improve Slack notification

### DIFF
--- a/CBI.Jenkinsfile
+++ b/CBI.Jenkinsfile
@@ -110,22 +110,20 @@ spec:
       script {
         def envName = ''
         if (env.JENKINS_URL.contains('ci.eclipse.org/xtext')) {
-          envName = ' (JIPP)'
+          envName = ' (JIRO)'
         } else if (env.JENKINS_URL.contains('ci-staging.eclipse.org/xtext')) {
           envName = ' (JIRO)'
-        } else if (env.JENKINS_URL.contains('jenkins.eclipse.org/xtext')) {
-          envName = ' (CBI)'
-        } else if (env.JENKINS_URL.contains('typefox.io')) {
-          envName = ' (TF)'
         }
         
         def curResult = currentBuild.currentResult
         def color = '#00FF00'
-        if (curResult == 'SUCCESS' && currentBuild.previousBuild != null) {
-          curResult = 'FIXED'
+        if (curResult == 'SUCCESS') {
+           if (currentBuild.previousBuild != null && currentBuild.previousBuild.result != 'SUCCESS') {
+             curResult = 'FIXED'
+           }
         } else if (curResult == 'UNSTABLE') {
           color = '#FFFF00'
-        } else if (curResult == 'FAILURE') {
+        } else { // FAILURE, ABORTED, NOT_BUILD
           color = '#FF0000'
         }
         

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,19 +55,19 @@ pipeline {
         def envName = ''
         if (env.JENKINS_URL.contains('ci.eclipse.org/xtext')) {
           envName = ' (JIPP)'
-        } else if (env.JENKINS_URL.contains('jenkins.eclipse.org/xtext')) {
-          envName = ' (CBI)'
         } else if (env.JENKINS_URL.contains('typefox.io')) {
           envName = ' (TF)'
         }
         
         def curResult = currentBuild.currentResult
         def color = '#00FF00'
-        if (curResult == 'SUCCESS' && currentBuild.previousBuild != null) {
-          curResult = 'FIXED'
+        if (curResult == 'SUCCESS') {
+           if (currentBuild.previousBuild != null && currentBuild.previousBuild.result != 'SUCCESS') {
+             curResult = 'FIXED'
+           }
         } else if (curResult == 'UNSTABLE') {
           color = '#FFFF00'
-        } else if (curResult == 'FAILURE') {
+        } else { // FAILURE, ABORTED, NOT_BUILD
           color = '#FF0000'
         }
         


### PR DESCRIPTION
- Reduce envName to known environments per Jenkinsfile type:
  - Jenkinsfile: remove CBI
  - CBI.Jenkinsfile: remove CBI & TF
  - CBI.Jenkinsfile: rename JIPP => JIRO
- Mark FAILURE, ABORTED, NOT_BUILD red
- Report FIXED only when the previous build was finished not with
SUCCESS

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>