### PR TITLE
[eclipse/xtext#1508] Trigger downstream build

### DIFF
--- a/CBI.Jenkinsfile
+++ b/CBI.Jenkinsfile
@@ -55,6 +55,18 @@ spec:
     '''
     }
   }
+  
+  environment {
+    DOWNSTREAM_JOBS = 'xtext-eclipse,xtext-maven,xtext-web'
+  }
+
+  parameters {
+    booleanParam(
+      name: 'TRIGGER_DOWNSTREAM_BUILD', 
+      defaultValue: (env.BRANCH_NAME.startsWith('milestone')||env.BRANCH_NAME.startsWith('release')), 
+      description: 'Should downstream jobs for the same branch be triggered on successful build?'
+    )
+  }
 
   options {
     buildDiscarder(logRotator(numToKeepStr:'15'))
@@ -100,6 +112,17 @@ spec:
     }
     success {
       archiveArtifacts artifacts: 'build/**'
+      script {
+        if (TRIGGER_DOWNSTREAM_BUILD=='true') {
+          DOWNSTREAM_JOBS.split(',').each {
+            def downstreamUrl = new URL("${env.JENKINS_URL}/job/$it/job/${env.BRANCH_NAME}")
+            def boolean downstreamJobExists = sh(script: "curl -L -s -o /dev/null -I -w '%{http_code}' ${downstreamUrl}", returnStdout: true) == "200"
+            if (downstreamJobExists) {
+              build job: "$it/${env.BRANCH_NAME}", wait: false, parameters: [booleanParam(name: 'TRIGGER_DOWNSTREAM_BUILD', value: "$TRIGGER_DOWNSTREAM_BUILD")]
+            }
+          }
+        }
+      }
     }
     changed {
       script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,21 @@
 pipeline {
   agent any
 
+  environment {
+    DOWNSTREAM_JOBS = 'xtext-eclipse,xtext-maven,xtext-web'
+  }
+
+  parameters {
+    booleanParam(
+      name: 'TRIGGER_DOWNSTREAM_BUILD', 
+      defaultValue: (env.BRANCH_NAME.startsWith('milestone')||env.BRANCH_NAME.startsWith('release')), 
+      description: 'Should downstream jobs for the same branch be triggered on successful build?'
+    )
+  }
+
   options {
     buildDiscarder(logRotator(numToKeepStr:'15'))
+    disableConcurrentBuilds()
     timeout(time: 60, unit: 'MINUTES')
     timestamps()
   }
@@ -49,6 +62,17 @@ pipeline {
     }
     success {
       archiveArtifacts artifacts: 'build/**'
+      script {
+        if (TRIGGER_DOWNSTREAM_BUILD=='true') {
+          DOWNSTREAM_JOBS.split(',').each {
+            def downstreamUrl = new URL("${env.JENKINS_URL}/job/$it/job/${env.BRANCH_NAME}")
+            def boolean downstreamJobExists = sh(script: "curl -L -s -o /dev/null -I -w '%{http_code}' ${downstreamUrl}", returnStdout: true) == "200"
+            if (downstreamJobExists) {
+              build job: "$it/${env.BRANCH_NAME}", wait: false, parameters: [booleanParam(name: 'TRIGGER_DOWNSTREAM_BUILD', value: "$TRIGGER_DOWNSTREAM_BUILD")]
+            }
+          }
+        }
+      }
     }
     changed {
       script {


### PR DESCRIPTION
Introduce boolean parameter TRIGGER_DOWNSTREAM_BUILD. The parameter
defaults to false normally except for milestone/release branches.
When the TRIGGER_DOWNSTREAM_BUILD flag is set, a test for a downstream
job with the same branch name is done via a curl command. When the
downstream job exists, it is triggered and the parameter value
TRIGGER_DOWNSTREAM_BUILD is propagated.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>