### PR TITLE
[eclipse/xtext#1547] use maven-publish instead of maven plugin

### DIFF
--- a/1-gradle-build.sh
+++ b/1-gradle-build.sh
@@ -9,7 +9,7 @@ if [ -f "/.dockerenv" ]; then
 fi
 
 ./gradlew \
-  clean cleanGenerateXtext build createLocalMavenRepo \
+  clean cleanGenerateXtext build publish \
   -PuseJenkinsSnapshots=true \
   -PJENKINS_URL=$JENKINS_URL \
   -PcompileXtend=true \

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ subprojects {
 	group = 'org.eclipse.xtext'
 	version = rootProject.version
 	
+	apply plugin: 'maven-publish'
 	apply plugin: 'java'
 	apply plugin: 'io.spring.dependency-management'
 	dependencyManagement {
@@ -38,7 +39,6 @@ subprojects {
 		apply plugin: 'org.xtext.xtend'
 	}
 	apply plugin: 'eclipse'
-	apply plugin: 'maven'
 	
 	apply from: "${rootDir}/gradle/upstream-repositories.gradle"
 	apply from: "${rootDir}/gradle/java-compiler-settings.gradle"

--- a/gradle/developers.gradle
+++ b/gradle/developers.gradle
@@ -2,108 +2,107 @@
  * Information on Xtext developers used in generated pom files for Maven publishing.
  */
 
-project {
-	developers {
-		developer {
-			name = 'Sven Efftinge'
-			email = 'sven.efftinge@typefox.io'
-			organization = 'TypeFox'
-			organizationUrl = 'http://typefox.io'
-		}
-		developer {
-			name = 'Sebastian Benz'
-		}
-		developer {
-			name = 'Lorenzo Bettini'
-			email = 'lorenzo.bettini@gmail.com'
-			organization = 'DISIA, University Firenze'
-		}
-		developer {
-			name = 'Michael Clay'
-		}
-		developer {
-			name = 'Arne Deutsch'
-			email = 'arne.deutsch@itemis.de'
-			organization = 'itemis'
-			organizationUrl = 'http://www.itemis.com'
-		}
-		developer {
-			name = 'Christian Dietrich'
-			email = 'christian.dietrich@itemis.de'
-			organization = 'itemis'
-			organizationUrl = 'http://www.itemis.com'
-		}
-		developer {
-			name = 'Moritz Eysholdt'
-			email = 'moritz.eysholdt@typefox.io'
-			organization = 'TypeFox'
-			organizationUrl = 'http://typefox.io'
-		}
-		developer {
-			name = 'Dennis Hübner'
-			email = 'dennis.huebner@typefox.io'
-			organization = 'TypeFox'
-			organizationUrl = 'http://typefox.io'
-		}
-		developer {
-			name = 'Jan Köhnlein'
-			email = 'jan.koehnlein@typefox.io'
-			organization = 'TypeFox'
-			organizationUrl = 'http://typefox.io'
-		}
-		developer {
-			name = 'Anton Kosyakov'
-			email = 'anton.kosyakov@typefox.io'
-			organization = 'TypeFox'
-			organizationUrl = 'http://typefox.io'
-		}
-		developer {
-			name = 'Tamas Miklossy'
-			email = 'miklossy@itemis.de'
-			organization = 'itemis'
-			organizationUrl = 'http://www.itemis.com'
-		}
-		developer {
-			name = 'Stefan Oehme'
-		}
-		developer {
-			name = 'Holger Schill'
-			email = 'holger.schill@itemis.de'
-			organization = 'itemis'
-			organizationUrl = 'http://www.itemis.com'
-		}
-		developer {
-			name = 'Christian Schneider'
-			email = 'christian.schneider@typefox.io'
-			organization = 'TypeFox'
-			organizationUrl = 'http://typefox.io'
-		}
-		developer {
-			name = 'Miro Spönemann'
-			email = 'miro.spoenemann@typefox.io'
-			organization = 'TypeFox'
-			organizationUrl = 'http://typefox.io'
-		}
-		developer {
-			name = 'Karsten Thoms'
-			email = 'karsten.thoms@itemis.de'
-			organization = 'itemis'
-			organizationUrl = 'http://www.itemis.com'
-		}
-		developer {
-			name = 'Knut Wannheden'
-		}
-		developer {
-			name = 'Sebastian Zarnekow'
-			email = 'sebastian.zarnekow@gmail.com'
-			organization = 'itemis'
-			organizationUrl = 'http://www.itemis.com'
-		}
-		developer {
-			name = 'Titouan Vervack'
-			email = 'titouan.vervack@sigasi.com'
-			organization = 'Sigasi'
-			organizationUrl = 'https://www.sigasi.com'
-		}
+developers {
+	developer {
+		name = 'Sven Efftinge'
+		email = 'sven.efftinge@typefox.io'
+		organization = 'TypeFox'
+		organizationUrl = 'http://typefox.io'
+	}
+	developer {
+		name = 'Sebastian Benz'
+	}
+	developer {
+		name = 'Lorenzo Bettini'
+		email = 'lorenzo.bettini@gmail.com'
+		organization = 'DISIA, University Firenze'
+	}
+	developer {
+		name = 'Michael Clay'
+	}
+	developer {
+		name = 'Arne Deutsch'
+		email = 'arne.deutsch@itemis.de'
+		organization = 'itemis'
+		organizationUrl = 'http://www.itemis.com'
+	}
+	developer {
+		name = 'Christian Dietrich'
+		email = 'christian.dietrich@itemis.de'
+		organization = 'itemis'
+		organizationUrl = 'http://www.itemis.com'
+	}
+	developer {
+		name = 'Moritz Eysholdt'
+		email = 'moritz.eysholdt@typefox.io'
+		organization = 'TypeFox'
+		organizationUrl = 'http://typefox.io'
+	}
+	developer {
+		name = 'Dennis Hübner'
+		email = 'dennis.huebner@typefox.io'
+		organization = 'TypeFox'
+		organizationUrl = 'http://typefox.io'
+	}
+	developer {
+		name = 'Jan Köhnlein'
+		email = 'jan.koehnlein@typefox.io'
+		organization = 'TypeFox'
+		organizationUrl = 'http://typefox.io'
+	}
+	developer {
+		name = 'Anton Kosyakov'
+		email = 'anton.kosyakov@typefox.io'
+		organization = 'TypeFox'
+		organizationUrl = 'http://typefox.io'
+	}
+	developer {
+		name = 'Tamas Miklossy'
+		email = 'miklossy@itemis.de'
+		organization = 'itemis'
+		organizationUrl = 'http://www.itemis.com'
+	}
+	developer {
+		name = 'Stefan Oehme'
+	}
+	developer {
+		name = 'Holger Schill'
+		email = 'holger.schill@itemis.de'
+		organization = 'itemis'
+		organizationUrl = 'http://www.itemis.com'
+	}
+	developer {
+		name = 'Christian Schneider'
+		email = 'christian.schneider@typefox.io'
+		organization = 'TypeFox'
+		organizationUrl = 'http://typefox.io'
+	}
+	developer {
+		name = 'Miro Spönemann'
+		email = 'miro.spoenemann@typefox.io'
+		organization = 'TypeFox'
+		organizationUrl = 'http://typefox.io'
+	}
+	developer {
+		name = 'Karsten Thoms'
+		email = 'karsten.thoms@itemis.de'
+		organization = 'itemis'
+		organizationUrl = 'http://www.itemis.com'
+	}
+	developer {
+		name = 'Knut Wannheden'
+	}
+	developer {
+		name = 'Sebastian Zarnekow'
+		email = 'sebastian.zarnekow@gmail.com'
+		organization = 'itemis'
+		organizationUrl = 'http://www.itemis.com'
+	}
+	developer {
+		name = 'Titouan Vervack'
+		email = 'titouan.vervack@sigasi.com'
+		organization = 'Sigasi'
+		organizationUrl = 'https://www.sigasi.com'
 	}
 }
+

--- a/gradle/maven-deployment.gradle
+++ b/gradle/maven-deployment.gradle
@@ -2,42 +2,44 @@
  * Configuration of deployment to Maven repositories.
  */
 
-// Configuration function for generated POMs
-def configurePom = { pom ->
-	pom.project {
-		if (project.hasProperty('title')) {
-			name = project.title
-			description = project.description
-		}
-		packaging 'jar'
-		url 'https://www.eclipse.org/Xtext/'
-		licenses {
-			license {
-				name 'Eclipse Public License, Version 1.0'
-				url 'http://www.eclipse.org/legal/epl-v10.html'
-			}
-		}
-		scm {
-			connection "scm:git:git@github.com:eclipse/${rootProject.name}.git"
-			developerConnection "scm:git:git@github.com:eclipse/${rootProject.name}.git"
-			url "git@github.com:eclipse/${rootProject.name}.git"
-		}
-	}
-	apply from: "${rootDir}/gradle/developers.gradle", to: pom
-}
+def noJavaDoc = name.endsWith('tests') || name.contains('testlanguage')
+publishing {
+    publications {
+        LocalMavenRepo(MavenPublication) {
+            from components.java
+            artifact sourcesJar
+            if (!noJavaDoc) {
+                artifact javadocJar
+            }
+            pom {
+                url = 'https://www.eclipse.org/Xtext/'
+                licenses {
+                    license {
+                        name = 'Eclipse Public License, Version 1.0'
+                        url = 'http://www.eclipse.org/legal/epl-v10.html'
+                    }
+                }
+                scm {
+                    connection = "scm:git:git@github.com:eclipse/${rootProject.name}.git"
+                    developerConnection = "scm:git:git@github.com:eclipse/${rootProject.name}.git"
+                    url = "git@github.com:eclipse/${rootProject.name}.git"
+                }
+                // We need to wait until the project's own build file has been executed
+                // so we can use the title and description settings for setting up Maven publishing.
+                afterEvaluate {
+                    if (project.hasProperty('title')) {
+                        name = project.title
+                        description = project.description
+                    }
+                }
+            }
+            apply from: "${rootDir}/gradle/developers.gradle", to: pom
+        }
 
-// We need to wait until the project's own build file has been executed
-// so we can use the title and description settings for setting up Maven publishing.
-afterEvaluate {
-	
-	task createLocalMavenRepo(type: Upload) {
-		group = 'Upload'
-		description = 'Create or update the local Maven repository'
-		configuration = configurations.archives
-		repositories.mavenDeployer {
-			repository(url: "file:" + file("${rootDir}/build/maven-repository"))
-			configurePom(pom)
-		}
-	}
-	
+    }
+    repositories {
+        maven {
+            url = "$rootProject.buildDir/maven-repository"
+        }
+    }
 }


### PR DESCRIPTION
[eclipse/xtext#1547] use maven-publish instead of maven plugin
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>