### PR TITLE
[eclipse/xtext-eclipse#1220] fixed formatting of arraybrackets

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.xtend
@@ -111,7 +111,9 @@ class XbaseFormatter extends XtypeFormatter {
 	}
 
 	def dispatch void format(JvmGenericArrayTypeReference array, extension IFormattableDocument document) {
-		addReplacer(new ArrayBracketsFormattingReplacer(array.regionFor.ruleCallTo(arrayBracketsRule)))
+		for (region : array.regionFor.ruleCallsTo(arrayBracketsRule)) {
+			addReplacer(new ArrayBracketsFormattingReplacer(region))
+		}
 		array.componentType.format
 	}
 

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.java
@@ -217,9 +217,11 @@ public class XbaseFormatter extends XtypeFormatter {
   }
   
   protected void _format(final JvmGenericArrayTypeReference array, @Extension final IFormattableDocument document) {
-    ISemanticRegion _ruleCallTo = this.textRegionExtensions.regionFor(array).ruleCallTo(this.grammar.getArrayBracketsRule());
-    ArrayBracketsFormattingReplacer _arrayBracketsFormattingReplacer = new ArrayBracketsFormattingReplacer(_ruleCallTo);
-    document.addReplacer(_arrayBracketsFormattingReplacer);
+    List<ISemanticRegion> _ruleCallsTo = this.textRegionExtensions.regionFor(array).ruleCallsTo(this.grammar.getArrayBracketsRule());
+    for (final ISemanticRegion region : _ruleCallsTo) {
+      ArrayBracketsFormattingReplacer _arrayBracketsFormattingReplacer = new ArrayBracketsFormattingReplacer(region);
+      document.addReplacer(_arrayBracketsFormattingReplacer);
+    }
     document.<JvmTypeReference>format(array.getComponentType());
   }
   


### PR DESCRIPTION
[eclipse/xtext-eclipse#1220] fixed formatting of arraybrackets
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>