### PR TITLE
[eclipse/xtext#1568] Remove Buildship classpath container

### DIFF
--- a/org.eclipse.xtext.common.types.tests/xtext.common.types.tests.launch
+++ b/org.eclipse.xtext.common.types.tests/xtext.common.types.tests.launch
@@ -11,7 +11,6 @@
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.xtext.common.types.tests"/>
 </launchConfiguration>

--- a/org.eclipse.xtext.purexbase.tests/xtext.purexbase.tests.launch
+++ b/org.eclipse.xtext.purexbase.tests/xtext.purexbase.tests.launch
@@ -11,7 +11,6 @@
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.xtext.purexbase.tests"/>
 </launchConfiguration>

--- a/org.eclipse.xtext.xbase.tests/org.eclipse.xtext.xbase.tests.smoke-suites.launch
+++ b/org.eclipse.xtext.xbase.tests/org.eclipse.xtext.xbase.tests.smoke-suites.launch
@@ -11,7 +11,6 @@
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.xtext.xbase.tests"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx1g"/>

--- a/org.eclipse.xtext.xbase.tests/xtext.xbase.tests.fast (xtend).launch
+++ b/org.eclipse.xtext.xbase.tests/xtext.xbase.tests.fast (xtend).launch
@@ -11,7 +11,6 @@
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.xtext.xbase.tests"/>
 </launchConfiguration>

--- a/org.eclipse.xtext.xbase.tests/xtext.xbase.tests.fast.launch
+++ b/org.eclipse.xtext.xbase.tests/xtext.xbase.tests.fast.launch
@@ -11,7 +11,6 @@
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.xtext.xbase.tests"/>
 </launchConfiguration>

--- a/org.eclipse.xtext.xbase.tests/xtext.xbase.tests.slow (xtend).launch
+++ b/org.eclipse.xtext.xbase.tests/xtext.xbase.tests.slow (xtend).launch
@@ -11,7 +11,6 @@
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.xtext.xbase.tests"/>
 </launchConfiguration>

--- a/org.eclipse.xtext.xbase.tests/xtext.xbase.tests.slow.launch
+++ b/org.eclipse.xtext.xbase.tests/xtext.xbase.tests.slow.launch
@@ -11,7 +11,6 @@
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.xtext.xbase.tests"/>
 </launchConfiguration>

--- a/org.eclipse.xtext.xbase/GenerateXbase.launch
+++ b/org.eclipse.xtext.xbase/GenerateXbase.launch
@@ -7,7 +7,6 @@
         <listEntry value="1"/>
     </listAttribute>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.xtext.xbase.GenerateXbase"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.xtext.xbase"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-DuiProject=${project_loc:/org.eclipse.xtext.xbase.ui}"/>


### PR DESCRIPTION
These changes were automatically applied to the launch configurations on
a fresh workspace setup.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>