### PR TITLE
[#419] Improve performance of Java source language

### DIFF
--- a/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.xtend
+++ b/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.xtend
@@ -50,7 +50,7 @@ class JavaDerivedStateComputer {
 		if (resource.compilationUnit !== null) {
 			val classFileCache = resource.resourceSet.findOrCreateClassFileCache
 			classFileCache.addResourceToCompile(resource)
-		} 
+		}
 	}
 	
 	def void installStubs(Resource resource) {

--- a/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.xtend
+++ b/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.xtend
@@ -109,7 +109,7 @@ class JavaDerivedStateComputer {
 	}
 	
 	def getCompilationUnit(Resource resource) {
-		(resource as JavaResource).getCompilationUnit()
+		return (resource as JavaResource).getCompilationUnit()
 	}
 	
 	protected def ClassFileCache findOrCreateClassFileCache(ResourceSet rs) {
@@ -118,7 +118,7 @@ class JavaDerivedStateComputer {
 			cache = new ClassFileCache
 			cache.attachToEmfObject(rs)
 		}
-		cache
+		return cache
 	}
 	
 	def void installFull(Resource resource) {
@@ -130,7 +130,7 @@ class JavaDerivedStateComputer {
 		
 		val data = resourceDescriptionsProvider.getResourceDescriptions(resource.resourceSet)
 		if (data === null)
-			throw new IllegalStateException("no index installed")
+			throw new IllegalStateException("No index installed")
 		
 		val (List<String>, Map<String, byte[]>)=>void initializer = [ topLevelTypes, classMap |
 			val inMemClassLoader = new InMemoryClassLoader(classMap, classLoader)
@@ -141,7 +141,7 @@ class JavaDerivedStateComputer {
 					val type = builder.buildType
 					resource.contents += type
 				} catch (Throwable t) {
-					throw new IllegalStateException("could not load type '" + topLevel + "'", t)
+					throw new IllegalStateException("Could not load type '" + topLevel + "'", t)
 				}
 			}
 		]
@@ -185,19 +185,19 @@ class JavaDerivedStateComputer {
 	
 	protected def isInfoFile(Resource resource) {
 		val name = resource.URI.trimFileExtension.lastSegment
-		name == "package-info" || name == "module-info"
+		return name == "package-info" || name == "module-info"
 	}
 	
 	protected def CompilerOptions getCompilerOptions() {
-		getCompilerOptions(null as JavaConfig)
+		return getCompilerOptions(null as JavaConfig)
 	}
 
 	protected def CompilerOptions getCompilerOptions(Resource resource) {
-		resource?.resourceSet.compilerOptions
+		return resource?.resourceSet?.compilerOptions
 	}
 
 	protected def CompilerOptions getCompilerOptions(ResourceSet resourceSet) {
-		JavaConfig?.findInEmfObject(resourceSet).compilerOptions
+		return JavaConfig.findInEmfObject(resourceSet).compilerOptions
 	}
 
 	protected def CompilerOptions getCompilerOptions(JavaConfig javaConfig) {
@@ -222,11 +222,11 @@ class JavaDerivedStateComputer {
 	}
 
 	protected def long toJdtVersion(JavaVersion version) {
-		version.toJdtClassFileConstant
+		return version.toJdtClassFileConstant
 	}
 	
 	protected def ClassLoader getClassLoader(Resource it) {
-		(resourceSet as XtextResourceSet).classpathURIContext as ClassLoader 
+		return (resourceSet as XtextResourceSet).classpathURIContext as ClassLoader 
 	}
 	
 }

--- a/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.xtend
+++ b/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.xtend
@@ -144,7 +144,7 @@ class JavaDerivedStateComputer {
 					throw new IllegalStateException("could not load type '" + topLevel + "'", t)
 				}
 			}
-		] 	
+		]
 		val wasCached = classFileCache.popCompileResult(compilationUnit.fileName, initializer)
 		
 		if (!wasCached) {

--- a/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.xtend
+++ b/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.xtend
@@ -30,6 +30,8 @@ import org.eclipse.xtext.resource.IResourceDescriptionsProvider
 import org.eclipse.xtext.resource.XtextResourceSet
 import org.eclipse.xtext.util.JavaVersion
 import org.eclipse.xtext.util.internal.Log
+import java.util.Map
+import java.util.HashSet
 
 @Log
 class JavaDerivedStateComputer {
@@ -43,7 +45,12 @@ class JavaDerivedStateComputer {
 		for (eObject : resourcesContentsList) {
 			unloader.unloadRoot(eObject) 
 		}
-		resource.getContents().clear 
+		resource.getContents().clear
+		
+		if (resource.compilationUnit !== null) {
+			val classFileCache = resource.resourceSet.findOrCreateClassFileCache
+			classFileCache.addResourceToCompile(resource)
+		} 
 	}
 	
 	def void installStubs(Resource resource) {
@@ -124,14 +131,34 @@ class JavaDerivedStateComputer {
 		val data = resourceDescriptionsProvider.getResourceDescriptions(resource.resourceSet)
 		if (data === null)
 			throw new IllegalStateException("no index installed")
-		// TODO use container manager
-		val nameEnv = new IndexAwareNameEnvironment(resource, classLoader, data, stubGenerator, classFileCache)
-		val compiler = new Compiler(nameEnv, DefaultErrorHandlingPolicies.proceedWithAllProblems(), resource.compilerOptions, [
-			for (cls : it.classFiles) {
-				val key = QualifiedName.create(CharOperation.toStrings(cls.compoundName))
-				classFileCache.computeIfAbsent(key, [name|new ClassFileReader(cls.bytes, cls.fileName)])
+		
+		val (List<String>, Map<String, byte[]>)=>void initializer = [ topLevelTypes, classMap |
+			val inMemClassLoader = new InMemoryClassLoader(classMap, classLoader)
+			for (topLevel : topLevelTypes) {
+				try {
+					val builder = new JvmDeclaredTypeBuilder(new BinaryClass(topLevel, inMemClassLoader),
+						new ClassFileBytesAccess(), inMemClassLoader)
+					val type = builder.buildType
+					resource.contents += type
+				} catch (Throwable t) {
+					throw new IllegalStateException("could not load type '" + topLevel + "'", t)
+				}
 			}
-			if (Arrays.equals(it.fileName, compilationUnit.fileName)) {
+		] 	
+		val wasCached = classFileCache.popCompileResult(compilationUnit.fileName, initializer)
+		
+		if (!wasCached) {
+			// TODO use container manager
+			
+			val unitsToCompile = new HashSet(classFileCache.drainResourcesToCompile.map[ it.compilationUnit ].toList)
+			unitsToCompile.add(compilationUnit)
+			
+			val nameEnv = new IndexAwareNameEnvironment(resource, classLoader, data, stubGenerator, classFileCache)
+			val compiler = new Compiler(nameEnv, DefaultErrorHandlingPolicies.proceedWithAllProblems(), resource.compilerOptions, [
+				for (cls : it.classFiles) {
+					val key = QualifiedName.create(CharOperation.toStrings(cls.compoundName))
+					classFileCache.computeIfAbsent(key, [name|new ClassFileReader(cls.bytes, cls.fileName)])
+				}
 				val map = newHashMap
 				var List<String> topLevelTypes = newArrayList
 				for (cf : it.getClassFiles()) {
@@ -141,20 +168,14 @@ class JavaDerivedStateComputer {
 						topLevelTypes += className
 					}
 				}
-				val inMemClassLoader = new InMemoryClassLoader(map, classLoader)
-				for (topLevel : topLevelTypes) {
-					try {
-                        val builder = new JvmDeclaredTypeBuilder(new BinaryClass(topLevel, inMemClassLoader),
-                            new ClassFileBytesAccess(), inMemClassLoader)
-                        val type = builder.buildType
-                        resource.contents += type
-                    } catch (Throwable t) {
-                        throw new IllegalStateException("could not load type '" + topLevel + "'", t)
-                    }
+				if (Arrays.equals(it.fileName, compilationUnit.fileName)) {
+					initializer.apply(topLevelTypes, map)
+				} else {
+					classFileCache.addCompileResult(it.fileName, topLevelTypes, map)
 				}
-			}
-		], new DefaultProblemFactory())
-		compiler.compile(#[compilationUnit])
+			], new DefaultProblemFactory())
+			compiler.compile(unitsToCompile)
+		}
 	}
 	
 	protected def isInfoFile(Resource resource) {
@@ -163,40 +184,41 @@ class JavaDerivedStateComputer {
 	}
 	
 	protected def CompilerOptions getCompilerOptions() {
-        getCompilerOptions(null as JavaConfig)
-    }
+		getCompilerOptions(null as JavaConfig)
+	}
 
-    protected def CompilerOptions getCompilerOptions(Resource resource) {
-        resource?.resourceSet.compilerOptions
-    }
+	protected def CompilerOptions getCompilerOptions(Resource resource) {
+		resource?.resourceSet.compilerOptions
+	}
 
-    protected def CompilerOptions getCompilerOptions(ResourceSet resourceSet) {
-        JavaConfig?.findInEmfObject(resourceSet).compilerOptions
-    }
+	protected def CompilerOptions getCompilerOptions(ResourceSet resourceSet) {
+		JavaConfig?.findInEmfObject(resourceSet).compilerOptions
+	}
 
-    protected def CompilerOptions getCompilerOptions(JavaConfig javaConfig) {
-        val sourceVersion = javaConfig?.javaSourceLevel ?: JavaVersion.JAVA8
-        val targetVersion = javaConfig?.javaTargetLevel ?: JavaVersion.JAVA8
-        if (sourceVersion == JavaVersion.JAVA7) {
-            LOG.warn("The java source language has been configured with Java 7. JDT will not produce signature information for generic @Override methods in this version, which might lead to follow up issues.")
-        }
-        val sourceLevel = sourceVersion.toJdtVersion
-        val targetLevel = targetVersion.toJdtVersion
-        val compilerOptions = new CompilerOptions
-        compilerOptions.targetJDK = targetLevel
-        compilerOptions.inlineJsrBytecode = true
-        compilerOptions.sourceLevel = sourceLevel
-        compilerOptions.produceMethodParameters = true
-        compilerOptions.produceReferenceInfo = true
-        compilerOptions.originalSourceLevel = targetLevel
-        compilerOptions.complianceLevel = sourceLevel
-        compilerOptions.originalComplianceLevel = targetLevel
-        return compilerOptions
-    }
+	protected def CompilerOptions getCompilerOptions(JavaConfig javaConfig) {
+		val sourceVersion = javaConfig?.javaSourceLevel ?: JavaVersion.JAVA8
+		val targetVersion = javaConfig?.javaTargetLevel ?: JavaVersion.JAVA8
+		if (sourceVersion == JavaVersion.JAVA7) {
+			LOG.warn(
+				"The java source language has been configured with Java 7. JDT will not produce signature information for generic @Override methods in this version, which might lead to follow up issues.")
+		}
+		val sourceLevel = sourceVersion.toJdtVersion
+		val targetLevel = targetVersion.toJdtVersion
+		val compilerOptions = new CompilerOptions
+		compilerOptions.targetJDK = targetLevel
+		compilerOptions.inlineJsrBytecode = true
+		compilerOptions.sourceLevel = sourceLevel
+		compilerOptions.produceMethodParameters = true
+		compilerOptions.produceReferenceInfo = true
+		compilerOptions.originalSourceLevel = targetLevel
+		compilerOptions.complianceLevel = sourceLevel
+		compilerOptions.originalComplianceLevel = targetLevel
+		return compilerOptions
+	}
 
-    protected def long toJdtVersion(JavaVersion version) {
-        version.toJdtClassFileConstant
-    }
+	protected def long toJdtVersion(JavaVersion version) {
+		version.toJdtClassFileConstant
+	}
 	
 	protected def ClassLoader getClassLoader(Resource it) {
 		(resourceSet as XtextResourceSet).classpathURIContext as ClassLoader 

--- a/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.xtend
+++ b/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.xtend
@@ -148,7 +148,12 @@ class JavaDerivedStateComputer {
 		val wasCached = classFileCache.popCompileResult(compilationUnit.fileName, initializer)
 		
 		if (!wasCached) {
-			// TODO use container manager
+			/*
+			 * TODO use container manager to respect the exact class visibility semantics
+			 * 
+			 * E.g. we could create a proper classloader hierarchy according to the results of the container manager
+			 * rather than flattening everything into a single classloader / name env.
+			 */
 			
 			val unitsToCompile = new HashSet(classFileCache.drainResourcesToCompile.map[ it.compilationUnit ].toList)
 			unitsToCompile.add(compilationUnit)

--- a/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.java
+++ b/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.java
@@ -185,17 +185,13 @@ public class JavaDerivedStateComputer {
   }
   
   protected ClassFileCache findOrCreateClassFileCache(final ResourceSet rs) {
-    ClassFileCache _xblockexpression = null;
-    {
-      ClassFileCache cache = ClassFileCache.findInEmfObject(rs);
-      if ((cache == null)) {
-        ClassFileCache _classFileCache = new ClassFileCache();
-        cache = _classFileCache;
-        cache.attachToEmfObject(rs);
-      }
-      _xblockexpression = cache;
+    ClassFileCache cache = ClassFileCache.findInEmfObject(rs);
+    if ((cache == null)) {
+      ClassFileCache _classFileCache = new ClassFileCache();
+      cache = _classFileCache;
+      cache.attachToEmfObject(rs);
     }
-    return _xblockexpression;
+    return cache;
   }
   
   public void installFull(final Resource resource) {
@@ -208,7 +204,7 @@ public class JavaDerivedStateComputer {
     final ClassLoader classLoader = this.getClassLoader(resource);
     final IResourceDescriptions data = this.resourceDescriptionsProvider.getResourceDescriptions(resource.getResourceSet());
     if ((data == null)) {
-      throw new IllegalStateException("no index installed");
+      throw new IllegalStateException("No index installed");
     }
     final Procedure2<List<String>, Map<String, byte[]>> _function = (List<String> topLevelTypes, Map<String, byte[]> classMap) -> {
       final InMemoryClassLoader inMemClassLoader = new InMemoryClassLoader(classMap, classLoader);
@@ -223,7 +219,7 @@ public class JavaDerivedStateComputer {
         } catch (final Throwable _t) {
           if (_t instanceof Throwable) {
             final Throwable t = (Throwable)_t;
-            throw new IllegalStateException((("could not load type \'" + topLevel) + "\'"), t);
+            throw new IllegalStateException((("Could not load type \'" + topLevel) + "\'"), t);
           } else {
             throw Exceptions.sneakyThrow(_t);
           }
@@ -285,12 +281,8 @@ public class JavaDerivedStateComputer {
   }
   
   protected boolean isInfoFile(final Resource resource) {
-    boolean _xblockexpression = false;
-    {
-      final String name = resource.getURI().trimFileExtension().lastSegment();
-      _xblockexpression = (Objects.equal(name, "package-info") || Objects.equal(name, "module-info"));
-    }
-    return _xblockexpression;
+    final String name = resource.getURI().trimFileExtension().lastSegment();
+    return (Objects.equal(name, "package-info") || Objects.equal(name, "module-info"));
   }
   
   protected CompilerOptions getCompilerOptions() {
@@ -302,15 +294,15 @@ public class JavaDerivedStateComputer {
     if (resource!=null) {
       _resourceSet=resource.getResourceSet();
     }
-    return this.getCompilerOptions(_resourceSet);
+    CompilerOptions _compilerOptions = null;
+    if (_resourceSet!=null) {
+      _compilerOptions=this.getCompilerOptions(_resourceSet);
+    }
+    return _compilerOptions;
   }
   
   protected CompilerOptions getCompilerOptions(final ResourceSet resourceSet) {
-    JavaConfig _findInEmfObject = null;
-    if (JavaConfig.class!=null) {
-      _findInEmfObject=JavaConfig.findInEmfObject(resourceSet);
-    }
-    return this.getCompilerOptions(_findInEmfObject);
+    return this.getCompilerOptions(JavaConfig.findInEmfObject(resourceSet));
   }
   
   protected CompilerOptions getCompilerOptions(final JavaConfig javaConfig) {

--- a/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.java
+++ b/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.java
@@ -4,7 +4,9 @@ import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.EList;
@@ -58,6 +60,7 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure2;
 
 @Log
 @SuppressWarnings("all")
@@ -77,6 +80,12 @@ public class JavaDerivedStateComputer {
       this.unloader.unloadRoot(eObject);
     }
     resource.getContents().clear();
+    CompilationUnit _compilationUnit = this.getCompilationUnit(resource);
+    boolean _tripleNotEquals = (_compilationUnit != null);
+    if (_tripleNotEquals) {
+      final ClassFileCache classFileCache = this.findOrCreateClassFileCache(resource.getResourceSet());
+      classFileCache.addResourceToCompile(resource);
+    }
   }
   
   public void installStubs(final Resource resource) {
@@ -201,28 +210,55 @@ public class JavaDerivedStateComputer {
     if ((data == null)) {
       throw new IllegalStateException("no index installed");
     }
-    final IndexAwareNameEnvironment nameEnv = new IndexAwareNameEnvironment(resource, classLoader, data, this.stubGenerator, classFileCache);
-    IErrorHandlingPolicy _proceedWithAllProblems = DefaultErrorHandlingPolicies.proceedWithAllProblems();
-    CompilerOptions _compilerOptions = this.getCompilerOptions(resource);
-    final ICompilerRequestor _function = (CompilationResult it) -> {
-      ClassFile[] _classFiles = it.getClassFiles();
-      for (final ClassFile cls : _classFiles) {
-        {
-          final QualifiedName key = QualifiedName.create(CharOperation.toStrings(cls.getCompoundName()));
-          final Function<QualifiedName, IBinaryType> _function_1 = (QualifiedName name) -> {
-            try {
-              byte[] _bytes = cls.getBytes();
-              char[] _fileName = cls.fileName();
-              return new ClassFileReader(_bytes, _fileName);
-            } catch (Throwable _e) {
-              throw Exceptions.sneakyThrow(_e);
-            }
-          };
-          classFileCache.computeIfAbsent(key, _function_1);
+    final Procedure2<List<String>, Map<String, byte[]>> _function = (List<String> topLevelTypes, Map<String, byte[]> classMap) -> {
+      final InMemoryClassLoader inMemClassLoader = new InMemoryClassLoader(classMap, classLoader);
+      for (final String topLevel : topLevelTypes) {
+        try {
+          BinaryClass _binaryClass = new BinaryClass(topLevel, inMemClassLoader);
+          ClassFileBytesAccess _classFileBytesAccess = new ClassFileBytesAccess();
+          final JvmDeclaredTypeBuilder builder = new JvmDeclaredTypeBuilder(_binaryClass, _classFileBytesAccess, inMemClassLoader);
+          final JvmDeclaredType type = builder.buildType();
+          EList<EObject> _contents = resource.getContents();
+          _contents.add(type);
+        } catch (final Throwable _t) {
+          if (_t instanceof Throwable) {
+            final Throwable t = (Throwable)_t;
+            throw new IllegalStateException((("could not load type \'" + topLevel) + "\'"), t);
+          } else {
+            throw Exceptions.sneakyThrow(_t);
+          }
         }
       }
-      boolean _equals = Arrays.equals(it.fileName, compilationUnit.fileName);
-      if (_equals) {
+    };
+    final Procedure2<? super List<String>, ? super Map<String, byte[]>> initializer = _function;
+    final boolean wasCached = classFileCache.popCompileResult(compilationUnit.fileName, initializer);
+    if ((!wasCached)) {
+      final Function1<Resource, CompilationUnit> _function_1 = (Resource it) -> {
+        return this.getCompilationUnit(it);
+      };
+      List<CompilationUnit> _list = IterableExtensions.<CompilationUnit>toList(IterableExtensions.<Resource, CompilationUnit>map(classFileCache.drainResourcesToCompile(), _function_1));
+      final HashSet<CompilationUnit> unitsToCompile = new HashSet<CompilationUnit>(_list);
+      unitsToCompile.add(compilationUnit);
+      final IndexAwareNameEnvironment nameEnv = new IndexAwareNameEnvironment(resource, classLoader, data, this.stubGenerator, classFileCache);
+      IErrorHandlingPolicy _proceedWithAllProblems = DefaultErrorHandlingPolicies.proceedWithAllProblems();
+      CompilerOptions _compilerOptions = this.getCompilerOptions(resource);
+      final ICompilerRequestor _function_2 = (CompilationResult it) -> {
+        ClassFile[] _classFiles = it.getClassFiles();
+        for (final ClassFile cls : _classFiles) {
+          {
+            final QualifiedName key = QualifiedName.create(CharOperation.toStrings(cls.getCompoundName()));
+            final Function<QualifiedName, IBinaryType> _function_3 = (QualifiedName name) -> {
+              try {
+                byte[] _bytes = cls.getBytes();
+                char[] _fileName = cls.fileName();
+                return new ClassFileReader(_bytes, _fileName);
+              } catch (Throwable _e) {
+                throw Exceptions.sneakyThrow(_e);
+              }
+            };
+            classFileCache.computeIfAbsent(key, _function_3);
+          }
+        }
         final HashMap<String, byte[]> map = CollectionLiterals.<String, byte[]>newHashMap();
         List<String> topLevelTypes = CollectionLiterals.<String>newArrayList();
         ClassFile[] _classFiles_1 = it.getClassFiles();
@@ -235,29 +271,17 @@ public class JavaDerivedStateComputer {
             }
           }
         }
-        final InMemoryClassLoader inMemClassLoader = new InMemoryClassLoader(map, classLoader);
-        for (final String topLevel : topLevelTypes) {
-          try {
-            BinaryClass _binaryClass = new BinaryClass(topLevel, inMemClassLoader);
-            ClassFileBytesAccess _classFileBytesAccess = new ClassFileBytesAccess();
-            final JvmDeclaredTypeBuilder builder = new JvmDeclaredTypeBuilder(_binaryClass, _classFileBytesAccess, inMemClassLoader);
-            final JvmDeclaredType type = builder.buildType();
-            EList<EObject> _contents = resource.getContents();
-            _contents.add(type);
-          } catch (final Throwable _t) {
-            if (_t instanceof Throwable) {
-              final Throwable t = (Throwable)_t;
-              throw new IllegalStateException((("could not load type \'" + topLevel) + "\'"), t);
-            } else {
-              throw Exceptions.sneakyThrow(_t);
-            }
-          }
+        boolean _equals = Arrays.equals(it.fileName, compilationUnit.fileName);
+        if (_equals) {
+          initializer.apply(topLevelTypes, map);
+        } else {
+          classFileCache.addCompileResult(it.fileName, topLevelTypes, map);
         }
-      }
-    };
-    DefaultProblemFactory _defaultProblemFactory = new DefaultProblemFactory();
-    final org.eclipse.jdt.internal.compiler.Compiler compiler = new org.eclipse.jdt.internal.compiler.Compiler(nameEnv, _proceedWithAllProblems, _compilerOptions, _function, _defaultProblemFactory);
-    compiler.compile(new ICompilationUnit[] { compilationUnit });
+      };
+      DefaultProblemFactory _defaultProblemFactory = new DefaultProblemFactory();
+      final org.eclipse.jdt.internal.compiler.Compiler compiler = new org.eclipse.jdt.internal.compiler.Compiler(nameEnv, _proceedWithAllProblems, _compilerOptions, _function_2, _defaultProblemFactory);
+      compiler.compile(((ICompilationUnit[])Conversions.unwrapArray(unitsToCompile, ICompilationUnit.class)));
+    }
   }
   
   protected boolean isInfoFile(final Resource resource) {
@@ -314,7 +338,8 @@ public class JavaDerivedStateComputer {
     final JavaVersion targetVersion = _elvis_1;
     boolean _equals = Objects.equal(sourceVersion, JavaVersion.JAVA7);
     if (_equals) {
-      JavaDerivedStateComputer.LOG.warn("The java source language has been configured with Java 7. JDT will not produce signature information for generic @Override methods in this version, which might lead to follow up issues.");
+      JavaDerivedStateComputer.LOG.warn(
+        "The java source language has been configured with Java 7. JDT will not produce signature information for generic @Override methods in this version, which might lead to follow up issues.");
     }
     final long sourceLevel = this.toJdtVersion(sourceVersion);
     final long targetLevel = this.toJdtVersion(targetVersion);


### PR DESCRIPTION
[#419] Improve performance of Java source language

The patch is based on batched compilation of Java source files. Most of the time for the Java source language is eaten up by repetitive compilation of referenced Java files, if we compile each Java source file individually.
This is changed towards a queue of not-yet-compiled, fully installed Java source resources. As soon as a resource is compiled, it compiles all of its friends and caches the result. A subsequent request to fully install Java source resource contents will first consult the cache and reuse the available cached data, if any.