### PR TITLE
[eclipse/xtext-core#1418] removed redundant superinterface from generated ca parsers

### DIFF
--- a/org.eclipse.xtext.purexbase.ide/src-gen/org/eclipse/xtext/purexbase/ide/contentassist/antlr/PartialPureXbaseContentAssistParser.java
+++ b/org.eclipse.xtext.purexbase.ide/src-gen/org/eclipse/xtext/purexbase/ide/contentassist/antlr/PartialPureXbaseContentAssistParser.java
@@ -8,10 +8,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialPureXbaseContentAssistParser extends PureXbaseParser implements IPartialEditingContentAssistParser {
+public class PartialPureXbaseContentAssistParser extends PureXbaseParser {
 
 	private AbstractRule rule;
 


### PR DESCRIPTION
[eclipse/xtext-core#1418] removed redundant superinterface from generated ca parsers
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>