### PR TITLE
[eclipse/xtext-xtend#1035] Missing validation in context of static interface methods

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/override/OverrideTester.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/override/OverrideTester.java
@@ -257,7 +257,13 @@ public class OverrideTester {
 	
 	protected boolean isConflictingDefaultImplementation(AbstractResolvedOperation overriding, AbstractResolvedOperation overridden) {
 		JvmOperation ridingDecl = overriding.getDeclaration();
+		if (ridingDecl.isStatic()) {
+			return false;
+		}
 		JvmOperation riddenDecl = overridden.getDeclaration();
+		if (riddenDecl.isStatic()) {
+			return false;
+		}
 		if (isInterface(ridingDecl.getDeclaringType()) && isInterface(riddenDecl.getDeclaringType())
 				&& (!ridingDecl.isAbstract() || !riddenDecl.isAbstract())) {
 			LightweightTypeReference ridingTypeRef = overriding.getResolvedDeclarator();


### PR DESCRIPTION
[eclipse/xtext-xtend#1035] Missing validation in context of static interface methods