### PR TITLE
[eclipse/xtext#1738] avoid usage of icu.Transliterator

### DIFF
--- a/org.eclipse.xtext.extras.tests/deprecated/org/eclipse/xtext/generator/grammarAccess/UnicodeCharacterDatabaseNamesTest.java
+++ b/org.eclipse.xtext.extras.tests/deprecated/org/eclipse/xtext/generator/grammarAccess/UnicodeCharacterDatabaseNamesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -23,13 +23,17 @@ public class UnicodeCharacterDatabaseNamesTest extends Assert {
 		assertEquals("LATIN SMALL LETTER U WITH DIAERESIS",getCharacterName('ü'));
 		assertEquals("LATIN SMALL LETTER A WITH DIAERESIS",getCharacterName('ä'));
 		assertEquals("DIGIT NINE",getCharacterName('9'));
-		assertEquals("CJK UNIFIED IDEOGRAPH-4711",getCharacterName('\u4711'));
+		assertEquals("CJK UNIFIED IDEOGRAPHS EXTENSION A 4711",getCharacterName('\u4711'));
 	}
 	
 	@Test public void testSmoke() throws Exception {
 		for (int i = 0; i < 8000; i++) {
 			String characterName = getCharacterName((char)i);
-			assertNotNull("Character : "+((char)i),characterName);
+			if (Character.getType(i) == Character.UNASSIGNED) {
+				assertNull(characterName);
+			} else {
+				assertNotNull(i + " - Character : "+((char)i),characterName);
+			};
 		}
 	}
 	

--- a/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/grammarAccess/GrammarAccessUtil.java
+++ b/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/grammarAccess/GrammarAccessUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -243,7 +243,7 @@ public class GrammarAccessUtil {
 			return r;
 		StringBuffer b = new StringBuffer();
 		for (char c : text.toCharArray()) {
-			String n = UnicodeCharacterDatabaseNames.getCharacterName(c);
+			String n = Character.getName(c);
 			if (n != null)
 				b.append(n + " ");
 		}

--- a/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/grammarAccess/UnicodeCharacterDatabaseNames.java
+++ b/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/grammarAccess/UnicodeCharacterDatabaseNames.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,25 +8,21 @@
  *******************************************************************************/
 package org.eclipse.xtext.generator.grammarAccess;
 
-import com.ibm.icu.text.Transliterator;
-
 /**
  * @author Moritz Eysholdt
  * @author Sven Efftinge
+ * 
+ * @deprecated will be removed with Xtext 2.23
  */
-@Deprecated
+@Deprecated//(forRemoval=true)
 public class UnicodeCharacterDatabaseNames {
-
-	private static final Transliterator transliterator = Transliterator.getInstance("Any-Name");
 
 	/**
 	 * Returns the Unicode string name for a character.
 	 *
 	 */
 	public static String getCharacterName(char character) {
-		String transliterated = transliterator.transliterate(String.valueOf(character));
-		// returns strings in the for of SEMICOLON}
-		return transliterated.substring("\\N{".length(),transliterated.length()-"}".length());
+		return Character.getName(character);
 	}
 
 }


### PR DESCRIPTION
[eclipse/xtext#1738] avoid usage of icu.Transliterator
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>