### PR TITLE
[eclipse/xtext#1738] removed no longer needed icu dependency

### DIFF
--- a/org.eclipse.xtext.generator/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.generator/META-INF/MANIFEST.MF
@@ -70,8 +70,7 @@ Require-Bundle: org.eclipse.xtext.xtext.generator;visibility:=reexport,
  org.eclipse.core.runtime;bundle-version="3.13.0",
  org.eclipse.jdt.core;bundle-version="3.13.102";resolution:=optional
 Bundle-ActivationPolicy: lazy
-Import-Package: com.ibm.icu.text;version="4.0.0",
- org.apache.commons.logging;version="1.0.4";resolution:=optional;x-installation:=greedy,
+Import-Package: org.apache.commons.logging;version="1.0.4";resolution:=optional;x-installation:=greedy,
  org.apache.log4j;version="1.2.15"
 Automatic-Module-Name: org.eclipse.xtext.generator
 Eclipse-SourceReferences: eclipseSourceReferences

--- a/org.eclipse.xtext.purexbase/build.properties
+++ b/org.eclipse.xtext.purexbase/build.properties
@@ -18,7 +18,6 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu
+                     org.apache.log4j
 
 

--- a/org.eclipse.xtext.xbase/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase/META-INF/MANIFEST.MF
@@ -173,8 +173,7 @@ Export-Package: org.eclipse.xtext.xbase,
  org.eclipse.xtext.xtype,
  org.eclipse.xtext.xtype.impl;x-friends:="org.eclipse.xtend.core",
  org.eclipse.xtext.xtype.util;x-friends:="org.eclipse.xtend.core"
-Import-Package: com.ibm.icu.text;version="4.0.0";resolution:=optional,
- javax.annotation,
+Import-Package: javax.annotation,
  org.apache.log4j;version="1.2.15"
 Automatic-Module-Name: org.eclipse.xtext.xbase
 Eclipse-SourceReferences: eclipseSourceReferences


### PR DESCRIPTION
[eclipse/xtext#1738] removed no longer needed icu dependency
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>