### PR TITLE
Removed jnlp image name from pod template

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,6 @@ kind: Pod
 spec:
   containers:
   - name: jnlp
-    image: 'eclipsecbi/jenkins-jnlp-agent'
     args: ['\$(JENKINS_SECRET)', '\$(JENKINS_NAME)']
     resources:
       limits:


### PR DESCRIPTION
This should be a no-op for the build but it makes build jobs more independant from infrastructure changes / issues like https://bugs.eclipse.org/bugs/show_bug.cgi?id=563024.

Linked to eclipse/xtext#1769

Signed-off-by: Mikaël Barbero <mikael.barbero@eclipse-foundation.org>