### PR TITLE
GenerateXbaseTestLanguages: setting the generateEclipse flag to true.

### DIFF
--- a/org.eclipse.xtext.xbase.testlanguages/src/org/eclipse/xtext/xbase/testlanguages/GenerateXbaseTestLanguages.mwe2
+++ b/org.eclipse.xtext.xbase.testlanguages/src/org/eclipse/xtext/xbase/testlanguages/GenerateXbaseTestLanguages.mwe2
@@ -4,7 +4,7 @@ import org.eclipse.emf.mwe.utils.*
 import org.eclipse.xtext.xtext.generator.*
 
 var rootPath = ".."
-var generateEclipse = false
+var generateEclipse = true
 
 Workflow {
 	bean = StandaloneSetup {


### PR DESCRIPTION
Signed-off-by: Tamas Miklossy <miklossy@itemis.de>