### PR TITLE
[xbase] Protected visibility for doCastConversion().

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/TypeConvertingCompiler.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/TypeConvertingCompiler.java
@@ -213,12 +213,20 @@ public class TypeConvertingCompiler extends AbstractXbaseCompiler {
 		return getTypeComputationServices().getFunctionTypes().findImplementingOperation(closureType);
 	}
 	
-	private void doCastConversion(final LightweightTypeReference castTo, final ITreeAppendable b, final Later expression) {
-		b.append("((");
-		b.append(castTo);
-		b.append(")");
-		expression.exec(b);
-		b.append(")");
+	/**
+	 * Invoked to generate the Java cast operation to the given buffer.
+	 * 
+	 * @param castTo is the expected type of the cast expression.
+	 * @param buffer is the receiver of the Java expression.
+	 * @param expression is the expression that has to be casted.
+	 * @since 2.23
+	 */
+	protected void doCastConversion(final LightweightTypeReference castTo, final ITreeAppendable buffer, final Later expression) {
+		buffer.append("((");
+		buffer.append(castTo);
+		buffer.append(")");
+		expression.exec(buffer);
+		buffer.append(")");
 	}
 	
 	private boolean isFunction(LightweightTypeReference typeReference) {


### PR DESCRIPTION
The visibility of the function doCastConversion() in
TypeConvertingCompiler is increased to protected in order
to enable its call from the sub-types.

Signed-off-by: Stéphane Galland <galland@arakhne.org>