### PR TITLE
[releng] Update Orbit URL to https://download.eclipse.org/tools/orbit/downloads/2020-12

### DIFF
--- a/releng/releng-target/xtext-extras.target.target
+++ b/releng/releng-target/xtext-extras.target.target
@@ -18,7 +18,7 @@
 			<repository location="https://download.eclipse.org/releases/oxygen/201804111000"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 			<unit id="org.junit" version="4.12.0.v201504281640"/>
 			<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 			<unit id="com.google.guava" version="27.1.0.v20190517-1946"/>


### PR DESCRIPTION
This change was brought to you by your friendly Xtext Genie.