### PR TITLE
bugfix 'return void' in XbaseInterpreter

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/interpreter/impl/XbaseInterpreter.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/interpreter/impl/XbaseInterpreter.java
@@ -294,8 +294,13 @@ public class XbaseInterpreter implements IExpressionInterpreter {
 	}
 	
 	protected Object _doEvaluate(XReturnExpression returnExpr, IEvaluationContext context, CancelIndicator indicator) {
-		Object returnValue = internalEvaluate(returnExpr.getExpression(), context, indicator);
-		throw new ReturnValue(returnValue);
+		XExpression expression = returnExpr.getExpression();
+		if (expression != null) {
+			Object returnValue = internalEvaluate(returnExpr.getExpression(), context, indicator);
+			throw new ReturnValue(returnValue);
+		} else {
+			throw new ReturnValue(null);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Evaluating the following example with `XbaseInterpreter` yields an internal error:
```
def void foo(){
	return
}
def String bar(){
	foo();
	"bla"
}
bar()
```

The error is only shown in the console. The relevant stacktrace section is:
```
Caused by: java.lang.IllegalArgumentException: Unhandled parameter types: [null, org.eclipse.xtext.xbase.interpreter.impl.DefaultEvaluationContext@3a687ba6, org.eclipse.xtext.builder.MonitorBasedCancelIndicator@7f6af28f]
	at org.eclipse.xtext.xbase.interpreter.impl.XbaseInterpreter.doEvaluate(XbaseInterpreter.java:271)
	at org.eclipse.xtext.xbase.interpreter.impl.XbaseInterpreter.internalEvaluate(XbaseInterpreter.java:204)
	at org.eclipse.xtext.xbase.interpreter.impl.XbaseInterpreter._doEvaluate(XbaseInterpreter.java:285)
	at org.eclipse.xtext.xbase.interpreter.impl.XbaseInterpreter.doEvaluate(XbaseInterpreter.java:252)
	at org.eclipse.xtext.xbase.interpreter.impl.XbaseInterpreter.internalEvaluate(XbaseInterpreter.java:204)
	at org.eclipse.xtext.xbase.interpreter.impl.XbaseInterpreter._doEvaluate(XbaseInterpreter.java:447)
	at org.eclipse.xtext.xbase.interpreter.impl.XbaseInterpreter.doEvaluate(XbaseInterpreter.java:228)
	at org.eclipse.xtext.xbase.interpreter.impl.XbaseInterpreter.internalEvaluate(XbaseInterpreter.java:204)
	at org.eclipse.xtext.xbase.interpreter.impl.XbaseInterpreter.evaluate(XbaseInterpreter.java:190)
	at org.eclipse.xtext.mqrepl.interpreter.ModelQueryLanguageInterpreter.invokeOperation(ModelQueryLanguageInterpreter.java:58)
```

The patch does not assume that `return` always has an expression which can be given `internalEvaluate`.

Signed-off-by: Andreas Heiduk <asheiduk@gmail.com>