### PR TITLE
https://github.com/eclipse/xtext/issues/1862 Guava 30.1.0

### DIFF
--- a/org.eclipse.xtext.common.types/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.common.types/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle:
  org.eclipse.xtext,
  org.objectweb.asm;bundle-version="[9.0.0,9.1.0)",
  org.eclipse.xtend.lib,
- com.google.guava;bundle-version="[27.1.0,28.0.0)",
+ com.google.guava;bundle-version="[30.1.0,31.0.0)",
  io.github.classgraph;bundle-version="4.8.35"
 Import-Package: org.apache.commons.logging;version="1.0.4";resolution:=optional,
  org.apache.log4j;version="1.2.15"

--- a/releng/releng-target/xtext-extras.target.target
+++ b/releng/releng-target/xtext-extras.target.target
@@ -21,7 +21,7 @@
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/2021-03"/>
 			<unit id="org.junit" version="4.12.0.v201504281640"/>
 			<unit id="org.objectweb.asm" version="9.0.0.v20201001-1419"/>
-			<unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
+			<unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
 			<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
 		</location>
 	</locations>


### PR DESCRIPTION
Update Google Guava version from 27.1.0 to 30.1.0

Signed-off-by: miklossy <miklossy@itemis.de>