### PR TITLE
[eclipse/xtext#1927] re-adjust bootstrapping targets for mwe(2)

### DIFF
--- a/releng/releng-target/xtext-extras.target.target
+++ b/releng/releng-target/xtext-extras.target.target
@@ -3,7 +3,7 @@
 <target name="org.eclipse.xtext.extras.target" sequenceNumber="0">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/S202101110955/"/>
+			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.25.0"/>
 			<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
[eclipse/xtext#1927] re-adjust bootstrapping targets for mwe(2)
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>