### PR TITLE
[eclipse/xtext#1928] Bootstrap against MWE(2) 1.6.1/2.12.1 Final

### DIFF
--- a/releng/releng-target/xtext-extras.target.target
+++ b/releng/releng-target/xtext-extras.target.target
@@ -11,7 +11,7 @@
 			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/milestones/S202102011009/"/>
+			<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.12.1/"/>
 			<unit id="org.eclipse.emf.mwe2.language.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
[eclipse/xtext#1928] Bootstrap against MWE(2) 1.6.1/2.12.1 Final
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>