### PR TITLE
[eclipse/xtext#1452] add common JavaRuntimeVersion utility to avoid code duplication between modules

### DIFF
--- a/org.eclipse.xtext.xbase.tests/longrunning/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractReturnTypeTest.java
+++ b/org.eclipse.xtext.xbase.tests/longrunning/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractReturnTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2020 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,7 +8,7 @@
  */
 package org.eclipse.xtext.xbase.tests.typesystem;
 
-import org.eclipse.xtext.xbase.tests.AbstractXbaseTestCase;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.junit.Test;
 
 /**
@@ -72,7 +72,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Test
 	@Override
 	public void testIfExpression_04() throws Exception {
-		if (AbstractXbaseTestCase.isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			resolvesTo("if (true) return '' else new StringBuilder", "Serializable & Comparable<?> & CharSequence");
 		} else {
 			resolvesTo("if (true) return '' else new StringBuilder", "Serializable & CharSequence");
@@ -112,7 +112,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Test
 	@Override
 	public void testIfExpression_28() throws Exception {
-		if (AbstractXbaseTestCase.isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo("if (true) return '' else 1", "Comparable<?> & Constable & ConstantDesc & Serializable");
 		} else {
 			resolvesTo("if (true) return '' else 1", "Comparable<?> & Serializable");
@@ -258,7 +258,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Test
 	@Override
 	public void testTryCatchFinallyExpression_11() throws Exception {
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo("try { return 'literal' as Object as Boolean } catch(ClassCastException e) return 'caught'",
 					"Serializable & Comparable<?> & Constable");
 		} else {
@@ -270,7 +270,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Test
 	@Override
 	public void testTryCatchFinallyExpression_12() throws Exception {
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo("try { return 'literal' as Object as Boolean } catch(ClassCastException e) {return 'caught'}",
 					"Serializable & Comparable<?> & Constable");
 		} else {
@@ -283,7 +283,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Override
 	public void testTryCatchFinallyExpression_13() throws Exception {
 		// @formatter:off
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo(
 					"try return 'literal' as Object as Boolean\n" +
 							"catch(NullPointerException e) return 'second thing is thrown'" +
@@ -303,7 +303,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Override
 	public void testTryCatchFinallyExpression_14() throws Exception {
 		// @formatter:off
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo(
 					"try return 'literal' as Object as Boolean\n"+
 							"catch(ClassCastException e) throw new NullPointerException()\n" +
@@ -334,7 +334,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Test
 	@Override
 	public void testTryCatchFinallyExpression_19() throws Exception {
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo("try { return 'literal' as Object as Boolean } catch(ClassCastException e) 'caught'", "Serializable & Comparable<?> & Constable");
 		} else {
 			resolvesTo("try { return 'literal' as Object as Boolean } catch(ClassCastException e) 'caught'", "Serializable & Comparable<?>");
@@ -344,7 +344,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Test
 	@Override
 	public void testTryCatchFinallyExpression_20() throws Exception {
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo("try { return 'literal' as Object as Boolean } catch(ClassCastException e) {'caught'}", "Serializable & Comparable<?> & Constable");
 		} else {
 			resolvesTo("try { return 'literal' as Object as Boolean } catch(ClassCastException e) {'caught'}", "Serializable & Comparable<?>");
@@ -355,7 +355,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Override
 	public void testTryCatchFinallyExpression_21() throws Exception {
 		// @formatter:off
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo(
 					"try return 'literal' as Object as Boolean\n" +
 							"catch(NullPointerException e) 'second thing is thrown'\n" +
@@ -375,7 +375,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Override
 	public void testTryCatchFinallyExpression_22() throws Exception {
 		// @formatter:off
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo(
 					"try return 'literal' as Object as Boolean\n" +
 							"catch(ClassCastException e) throw new NullPointerException()\n" +
@@ -394,7 +394,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Test
 	@Override
 	public void testTryCatchFinallyExpression_25() throws Exception {
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo("try true catch (Exception e) return 'bar' catch(RuntimeException e) return 'baz'", "Serializable & Comparable<?> & Constable");
 		} else {
 			resolvesTo("try true catch (Exception e) return 'bar' catch(RuntimeException e) return 'baz'", "Serializable & Comparable<?>");
@@ -404,7 +404,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Test
 	@Override
 	public void testTryCatchFinallyExpression_26() throws Exception {
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo("try 'foo' catch (Exception e) 'bar' catch(RuntimeException e) return true finally true",
 					"Serializable & Comparable<?> & Constable");
 		} else {
@@ -416,7 +416,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Test
 	@Override
 	public void testTryCatchFinallyExpression_27() throws Exception {
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo("try { 'literal' as Object as Boolean } catch(ClassCastException e) return 'caught'", "Serializable & Comparable<?> & Constable");
 		} else {
 			resolvesTo("try { 'literal' as Object as Boolean } catch(ClassCastException e) return 'caught'", "Serializable & Comparable<?>");
@@ -426,7 +426,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Test
 	@Override
 	public void testTryCatchFinallyExpression_28() throws Exception {
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo("try { 'literal' as Object as Boolean } catch(ClassCastException e) {return 'caught'}", "Serializable & Comparable<?> & Constable");
 		} else {
 			resolvesTo("try { 'literal' as Object as Boolean } catch(ClassCastException e) {return 'caught'}", "Serializable & Comparable<?>");
@@ -437,7 +437,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Override
 	public void testTryCatchFinallyExpression_29() throws Exception {
 		// @formatter:off
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo(
 					"try 'literal' as Object as Boolean\n" +
 							"catch(NullPointerException e) return 'second thing is thrown'\n" +
@@ -457,7 +457,7 @@ public abstract class AbstractReturnTypeTest<Reference extends Object> extends A
 	@Override
 	public void testTryCatchFinallyExpression_30() throws Exception {
 		// @formatter:off
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo(
 					"try 'literal' as Object as Boolean\n" +
 							"catch(ClassCastException e) throw new NullPointerException()\n" +

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/AbstractXbaseTestCase.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/AbstractXbaseTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,8 +9,6 @@
 package org.eclipse.xtext.xbase.tests;
 
 import java.io.IOException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -34,72 +32,6 @@ import com.google.inject.Provider;
 @RunWith(XtextRunner.class)
 @InjectWith(XbaseInjectorProvider.class)
 public abstract class AbstractXbaseTestCase extends Assert {
-	
-	private static final boolean isJava11OrLater = determineJava11OrLater();
-	
-	public static boolean isJava11OrLater() {
-		return isJava11OrLater;
-	}
-	
-	private static final boolean isJava12OrLater = determineJava12OrLater();
-	
-	public static boolean isJava12OrLater() {
-		return isJava12OrLater;
-	}
-	
-	private static final boolean isJava15OrLater = determineJava15OrLater();
-	
-	public static boolean isJava15OrLater() {
-		return isJava15OrLater;
-	}
-
-	private static boolean determineJava11OrLater() {
-		String javaVersion = System.getProperty("java.version");
-		try {
-			Pattern p = Pattern.compile("(\\d+)(.)*");
-			Matcher matcher = p.matcher(javaVersion);
-			if (matcher.matches()) {
-				String first = matcher.group(1);
-				int version = Integer.parseInt(first);
-				return version >= 11;
-			}
-		} catch (NumberFormatException e) {
-			// ok
-		}
-		return false;
-	}
-
-	private static boolean determineJava12OrLater() {
-		String javaVersion = System.getProperty("java.version");
-		try {
-			Pattern p = Pattern.compile("(\\d+)(.)*");
-			Matcher matcher = p.matcher(javaVersion);
-			if (matcher.matches()) {
-				String first = matcher.group(1);
-				int version = Integer.parseInt(first);
-				return version >= 12;
-			}
-		} catch (NumberFormatException e) {
-			// ok
-		}
-		return false;
-	}
-
-	private static boolean determineJava15OrLater() {
-		String javaVersion = System.getProperty("java.version");
-		try {
-			Pattern p = Pattern.compile("(\\d+)(.)*");
-			Matcher matcher = p.matcher(javaVersion);
-			if (matcher.matches()) {
-				String first = matcher.group(1);
-				int version = Integer.parseInt(first);
-				return version >= 15;
-			}
-		} catch (NumberFormatException e) {
-			// ok
-		}
-		return false;
-	}
 
 	@Inject
 	private Injector injector;

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractClosureTypeTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractClosureTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2020 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.XClosure;
 import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
@@ -1830,7 +1831,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_056() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			withEquivalents(resolvesClosuresTo(
 					"{ val list = newArrayList(if (false) new Double('-20') else new Integer('20')).map(v|v.intValue)" +
 				"	   val Object o = list.head " +
@@ -1850,7 +1851,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_057() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			withEquivalents(resolvesClosuresTo(
 					"{ val list = newArrayList(if (false) new Double('-20') else new Integer('20')).map(v|v.intValue)" +
 				"	   val Object o = list.head " +
@@ -1870,7 +1871,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_058() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			withEquivalents(resolvesClosuresTo(
 					"{ val list = $$ListExtensions::map(newArrayList(if (false) new Double('-20') else new Integer('20'))) [ v|v.intValue ]" +
 				"	   val Object o = list.head " +
@@ -1962,7 +1963,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_067() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			withEquivalents(resolvesClosuresTo(
 					"{ val list = newArrayList(new Double('-20'), new Integer('20')).map(v|v.intValue)" +
 				"	   val Object o = list.head " +
@@ -1982,7 +1983,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_068() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			withEquivalents(resolvesClosuresTo(
 					"{ val list = newArrayList(new Double('-20'), new Integer('20')).map(v|v.intValue)" +
 				"	   val Object o = list.head " +
@@ -2002,7 +2003,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_069() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			withEquivalents(resolvesClosuresTo(
 					"{ val list = $$ListExtensions::map(newArrayList(new Double('-20'), new Integer('20'))) [ v|v.intValue ]" +
 				"	   val Object o = list.head " +
@@ -2022,7 +2023,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_070() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			withEquivalents(resolvesClosuresTo(
 					"{ val list = $$ListExtensions::map(newArrayList(new Double('-20'), new Integer('20'))) [ v| return v.intValue ]" +
 				"	   val Object o = list.head " +
@@ -2387,7 +2388,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_126() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			withEquivalents(resolvesClosuresTo(
 					"{ val list = newArrayList(if (false) new Double('-20') else new Integer('20')).map(v| return v.intValue)" +
 				"	   val Object o = list.head " +
@@ -2407,7 +2408,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_127() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			withEquivalents(resolvesClosuresTo(
 					"{ val list = newArrayList(if (false) new Double('-20') else new Integer('20')).map(v| return v.intValue)" +
 				"	   val Object o = list.head " +
@@ -2427,7 +2428,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_128() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			withEquivalents(resolvesClosuresTo(
 					"{ val list = $$ListExtensions::map(newArrayList(if (false) new Double('-20') else new Integer('20'))) [ v| return v.intValue ]" +
 				"	   val Object o = list.head " +
@@ -2520,7 +2521,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_137() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			withEquivalents(resolvesClosuresTo(
 					"{ val list = newArrayList(new Double('-20'), new Integer('20')).map(v| return v.intValue)" +
 				"	   val Object o = list.head " +
@@ -2540,7 +2541,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_138() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			withEquivalents(resolvesClosuresTo(
 					"{ val list = newArrayList(new Double('-20'), new Integer('20')).map(v| return v.intValue)" +
 				"	   val Object o = list.head " +
@@ -2790,7 +2791,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testClosureWithReturnExpression_01() throws Exception {
-		if (isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			withEquivalents(resolvesClosuresTo("[ | if (true) return '' else return new StringBuilder ]",
 					"()=>Serializable & Comparable<?> & CharSequence"), "Function0<Serializable & Comparable<?> & CharSequence>");
 		} else {
@@ -2802,7 +2803,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testClosureWithReturnExpression_02() throws Exception {
-		if (isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			withEquivalents(resolvesClosuresTo("[ | if (true) '' else return new StringBuilder ]",
 					"()=>Serializable & Comparable<?> & CharSequence"), "Function0<Serializable & Comparable<?> & CharSequence>");
 		} else {
@@ -2813,7 +2814,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testClosureWithReturnExpression_03() throws Exception {
-		if (isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			withEquivalents(resolvesClosuresTo("[ | if (true) return '' else new StringBuilder ]",
 					"()=>Serializable & Comparable<?> & CharSequence"), "Function0<Serializable & Comparable<?> & CharSequence>");
 		} else {
@@ -2824,7 +2825,7 @@ public abstract class AbstractClosureTypeTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testClosureWithReturnExpression_04() throws Exception {
-		if (isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			withEquivalents(
 					resolvesClosuresTo("[ | if (true) '' else new StringBuilder ]", "()=>Serializable & Comparable<?> & CharSequence"),
 					"Function0<Serializable & Comparable<?> & CharSequence>");

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractConstructorCallTypeTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractConstructorCallTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2020 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.XConstructorCall;
 import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.XbasePackage;
@@ -278,7 +279,7 @@ public abstract class AbstractConstructorCallTypeTest extends AbstractXbaseTestC
 
 	@Test
 	public void testConstructorTypeInference_08() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesConstructorCallsTo("new testdata.GenericType2(new Integer(0), new Integer(0).doubleValue)",
 					"GenericType2<Number & Comparable<?> & Constable & ConstantDesc>", "Integer", "Integer");
 		} else {
@@ -705,7 +706,7 @@ public abstract class AbstractConstructorCallTypeTest extends AbstractXbaseTestC
 
 	@Test
 	public void testDeferredTypeArgumentResolution_084() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesConstructorCallsTo(
 				"{\n" +
 				"val list = new java.util.ArrayList\n" +
@@ -1268,7 +1269,7 @@ public abstract class AbstractConstructorCallTypeTest extends AbstractXbaseTestC
 
 	@Test
 	public void testDeferredTypeArgumentResolution_130() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesConstructorCallsTo(
 					"{\n" +
 				"val list = new java.util.ArrayList\n" +

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractFeatureCallTypeTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractFeatureCallTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2020 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.XAbstractFeatureCall;
 import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.XbasePackage;
@@ -1067,7 +1068,7 @@ public abstract class AbstractFeatureCallTypeTest extends AbstractXbaseTestCase 
 
 	@Test
 	public void testBug_406425_01() throws Exception {
-		if (isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			resolvesFeatureCallsTo(
 				"(null as StringBuilder) => [\n" +
 				"	newArrayList(it, new Long(0))\n" +
@@ -1778,7 +1779,7 @@ public abstract class AbstractFeatureCallTypeTest extends AbstractXbaseTestCase 
 
 	@Test
 	public void testFeatureCallWithOperatorOverloading_6() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesFeatureCallsTo(
 				"newHashMap( 5 -> '', '' -> 5 )",
 					"HashMap<Comparable<?> & Constable & ConstantDesc & Serializable, Comparable<?> & Constable & ConstantDesc & Serializable>",

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractIdentifiableTypeTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractIdentifiableTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2020 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -18,6 +18,7 @@ import org.eclipse.xtext.common.types.JvmFormalParameter;
 import org.eclipse.xtext.common.types.JvmIdentifiableElement;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.XClosure;
 import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.XVariableDeclaration;
@@ -752,7 +753,7 @@ public abstract class AbstractIdentifiableTypeTest extends AbstractXbaseTestCase
 
 	@Test
 	public void testFeatureCall_26() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesIdentifiablesTo(
 					"{ val list = newArrayList(if (false) new Double('-20') else new Integer('20')).map(v|v.intValue)\n" +
 				"   val Object o = list.head \n" +
@@ -771,7 +772,7 @@ public abstract class AbstractIdentifiableTypeTest extends AbstractXbaseTestCase
 
 	@Test
 	public void testFeatureCall_27() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesIdentifiablesTo(
 					"{ val list = $$ListExtensions::map(newArrayList(if (false) new Double('-20') else new Integer('20'))) [ v|v.intValue ]\n" +
 				"   val Object o = list.head \n" +

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractTypeArgumentTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractTypeArgumentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2020 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -20,6 +20,7 @@ import org.eclipse.xtext.common.types.JvmIdentifiableElement;
 import org.eclipse.xtext.common.types.JvmTypeParameterDeclarator;
 import org.eclipse.xtext.nodemodel.INode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.XAbstractFeatureCall;
 import org.eclipse.xtext.xbase.XConstructorCall;
 import org.eclipse.xtext.xbase.XExpression;
@@ -398,8 +399,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testOverloadedOperators_20() throws Exception {
-		boolean _isJava11OrLater = AbstractXbaseTestCase.isJava11OrLater();
-		if (_isJava11OrLater) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			done(
 					and(
 							bindTypeArgumentsTo(
@@ -1060,8 +1060,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testConstructorTypeInference_08() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(bindTypeArgumentsTo("new testdata.GenericType2(new Integer(0), new Integer(0).doubleValue)",
 					"Number & Comparable<?> & Constable & ConstantDesc"));
 		} else {
@@ -1089,8 +1088,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testVarArgs_01() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(bindTypeArgumentsTo("newArrayList(new Double('-20'), new Integer('20'))",
 					"Number & Comparable<?> & Constable & ConstantDesc"));
 		} else {
@@ -1100,8 +1098,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testVarArgs_02() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(bindTypeArgumentsTo("newArrayList(if (true) new Double('-20') else new Integer('20'))",
 					"Number & Comparable<?> & Constable & ConstantDesc"));
 		} else {
@@ -1112,8 +1109,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testVarArgs_03() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(bindTypeArgumentsTo("newArrayList(if (true) new Double('-20') else new Integer('20'), new Integer('29'))",
 					"Number & Comparable<?> & Constable & ConstantDesc"));
 		} else {
@@ -1124,8 +1120,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testVarArgs_04() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(bindTypeArgumentsTo("newArrayList(if (true) new Double('-20') else new Integer('20'), new Double('29'))",
 					"Number & Comparable<?> & Constable & ConstantDesc"));
 		} else {
@@ -1136,8 +1131,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testVarArgs_05() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(bindTypeArgumentsTo(
 					"newArrayList(if (true) new Double('-20') else new Integer('20'), new Integer('29'), new Double('29'))",
 					"Number & Comparable<?> & Constable & ConstantDesc"));
@@ -1180,8 +1174,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_07() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(bindTypeArgumentsTo("new testdata.ClassWithVarArgs().toList('', 1)",
 					"Comparable<?> & Constable & ConstantDesc & Serializable"));
 		} else {
@@ -1206,8 +1199,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_11() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(bindTypeArgumentsTo("new testdata.ClassWithVarArgs().toNumberList(new Integer(0), new Integer(0).doubleValue)",
 					"Number & Comparable<?> & Constable & ConstantDesc"));
 		} else {
@@ -1556,8 +1548,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_64() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(and(and(bindTypeArgumentsTo(
 					"{ val list = newArrayList(if (false) new Double('-20') else new Integer('20')).map(v|v.intValue)\n" +
 				"	   val Object o = list.head \n" +
@@ -1577,8 +1568,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_65() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(and(and(and(bindTypeArgumentsTo(
 					"{ val list = newArrayList(if (false) new Double('-20') else new Integer('20')).map(v|v.intValue)\n" +
 				"	   val Object o = list.head \n" +
@@ -1598,8 +1588,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_66() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(and(and(and(bindTypeArgumentsTo(
 					"{ val list = newArrayList(if (false) new Double('-20') else new Integer('20')).map(v|v.compareTo(null))\n" +
 				"	   val Object o = list.head \n" +
@@ -1619,8 +1608,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testFeatureCall_67() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(and(and(bindTypeArgumentsTo(
 					"{ val list = $$ListExtensions::map(newArrayList(if (false) new Double('-20') else new Integer('20'))) [ v|v.intValue ]\n" +
 				"	   val Object o = list.head \n" +
@@ -2320,8 +2308,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testDeferredTypeArgumentResolution_018() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(bindTypeArgumentsTo(
 					"{\n" +
 				"val list = newArrayList\n" +
@@ -2775,8 +2762,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testDeferredTypeArgumentResolution_064() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(and(and(bindTypeArgumentsTo(
 					"{\n" +
 				"val list = newArrayList\n" +
@@ -2991,8 +2977,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testDeferredTypeArgumentResolution_084() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(bindTypeArgumentsTo(
 					"{\n" +
 				"val list = new java.util.ArrayList\n" +
@@ -3463,8 +3448,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testDeferredTypeArgumentResolution_130() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(and(and(bindTypeArgumentsTo(
 					"{\n" +
 				"val list = new java.util.ArrayList\n" +
@@ -3732,8 +3716,7 @@ public abstract class AbstractTypeArgumentTest extends AbstractXbaseTestCase {
 
 	@Test
 	public void testDeferredTypeArgumentResolution_161() throws Exception {
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			done(and(bindTypeArgumentsTo(
 					"{\n" +
 				"val list = newArrayList\n" +

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractTypeResolverTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/AbstractTypeResolverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2020 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -15,6 +15,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.linking.impl.XtextLinkingDiagnostic;
 import org.eclipse.xtext.resource.XtextSyntaxDiagnostic;
 import org.eclipse.xtext.testing.smoketest.IgnoredBySmokeTest;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.lib.IntegerRange;
 import org.eclipse.xtext.xbase.tests.AbstractXbaseTestCase;
@@ -237,7 +238,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testStringLiteral_05() throws Exception {
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo("newArrayList(null as Character, '1')", "ArrayList<Serializable & Comparable<?> & Constable>");
 		} else {
 			resolvesTo("newArrayList(null as Character, '1')", "ArrayList<Serializable & Comparable<?>>");
@@ -246,7 +247,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testStringLiteral_06() throws Exception {
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo("newArrayList(null as Character, '11')", "ArrayList<Serializable & Comparable<?> & Constable>");
 		} else {
 			resolvesTo("newArrayList(null as Character, '11')", "ArrayList<Serializable & Comparable<?>>");
@@ -420,7 +421,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testListLiteral_05() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo("#[1, 2.0, 3]", "List<? extends Number & Comparable<?> & Constable & ConstantDesc>");
 		} else {
 			resolvesTo("#[1, 2.0, 3]", "List<? extends Number & Comparable<?>>");
@@ -499,7 +500,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testSetLiteral_05() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo("#{1, 2.0 ,3}", "Set<? extends Number & Comparable<?> & Constable & ConstantDesc>");
 		} else {
 			resolvesTo("#{1, 2.0 ,3}", "Set<? extends Number & Comparable<?>>");
@@ -814,7 +815,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testOverloadedOperators_20() throws Exception {
-		if (isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			resolvesTo("(null as Iterable<StringBuilder>) + (null as Iterable<StringBuffer>) + (null as Iterable<String>)",
 					"Iterable<Serializable & Comparable<?> & CharSequence>");
 		} else {
@@ -856,7 +857,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testTryCatchFinallyExpression_03() throws Exception {
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo("try { 'literal' as Object as Boolean } catch(ClassCastException e) 'caught'", "Serializable & Comparable<?> & Constable");
 		} else {
 			resolvesTo("try { 'literal' as Object as Boolean } catch(ClassCastException e) 'caught'", "Serializable & Comparable<?>");
@@ -865,7 +866,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testTryCatchFinallyExpression_04() throws Exception {
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo("try { 'literal' as Object as Boolean } catch(ClassCastException e) {'caught'}", "Serializable & Comparable<?> & Constable");
 		} else {
 			resolvesTo("try { 'literal' as Object as Boolean } catch(ClassCastException e) {'caught'}", "Serializable & Comparable<?>");
@@ -874,7 +875,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testTryCatchFinallyExpression_05() throws Exception {
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo(
 					"try 'literal' as Object as Boolean\n" +
 							"  catch(NullPointerException e) 'second thing is thrown'		  \n" +
@@ -891,7 +892,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testTryCatchFinallyExpression_06() throws Exception {
-		if (isJava15OrLater()) {
+		if (JavaRuntimeVersion.isJava15OrLater()) {
 			resolvesTo(
 					"try 'literal' as Object as Boolean\n" +
 							"  catch(ClassCastException e) throw new NullPointerException()\n" +
@@ -1703,7 +1704,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testIfExpression_02() throws Exception {
-		if (isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			resolvesTo("if (true) new StringBuilder() else new StringBuffer()", "AbstractStringBuilder & Serializable & Comparable<?>");
 		} else {
 			resolvesTo("if (true) new StringBuilder() else new StringBuffer()", "AbstractStringBuilder & Serializable");
@@ -1745,7 +1746,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testIfExpression_09() throws Exception {
-		if (isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			this.isFunctionAndEquivalentTo(
 					resolvesTo("if (true) [new StringBuilder()] else [new StringBuffer()]",
 							"(Object)=>AbstractStringBuilder & Serializable & Comparable<?>"),
@@ -1765,7 +1766,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testIfExpression_11() throws Exception {
-		if (isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			resolvesTo("(if (true) [new StringBuilder()] else [new StringBuffer()]).apply('')",
 					"AbstractStringBuilder & Serializable & Comparable<?>");
 		} else {
@@ -1780,7 +1781,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testIfExpression_13() throws Exception {
-		if (isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			resolvesTo("if (true) <StringBuffer>newArrayList else <String>newHashSet",
 					"AbstractCollection<? extends Serializable & Comparable<?> & CharSequence> & Serializable & Cloneable");
 		} else {
@@ -2047,7 +2048,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testTypeGuardedCase_0() throws Exception {
-		if (isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			resolvesTo("switch s: new Object() { String: s StringBuffer: s}", "Serializable & Comparable<?> & CharSequence");
 		} else {
 			resolvesTo("switch s: new Object() { String: s StringBuffer: s}", "Serializable & CharSequence");
@@ -2073,7 +2074,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testTypeGuardedCase_3() throws Exception {
-		if (isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			resolvesTo("switch s: new Object() { String, StringBuffer: s}", "Serializable & Comparable<?> & CharSequence");
 		} else {
 			resolvesTo("switch s: new Object() { String, StringBuffer: s}", "Serializable & CharSequence");
@@ -2381,7 +2382,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testConstructorTypeInference_08() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo("new testdata.GenericType2(new Integer(0), new Integer(0).doubleValue)",
 					"GenericType2<Number & Comparable<?> & Constable & ConstantDesc>");
 		} else {
@@ -2431,7 +2432,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testVarArgs_01() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo("newArrayList(new Double('-20'), new Integer('20'))",
 					"ArrayList<Number & Comparable<?> & Constable & ConstantDesc>");
 		} else {
@@ -2441,7 +2442,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testVarArgs_02() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo("newArrayList(if (true) new Double('-20') else new Integer('20'))",
 					"ArrayList<Number & Comparable<?> & Constable & ConstantDesc>");
 		} else {
@@ -2451,7 +2452,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testVarArgs_03() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo("newArrayList(if (true) new Double('-20') else new Integer('20'), new Integer('29'))",
 					"ArrayList<Number & Comparable<?> & Constable & ConstantDesc>");
 		} else {
@@ -2462,7 +2463,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testVarArgs_04() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo("newArrayList(if (true) new Double('-20') else new Integer('20'), new Double('29'))",
 					"ArrayList<Number & Comparable<?> & Constable & ConstantDesc>");
 		} else {
@@ -2473,7 +2474,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testVarArgs_05() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo("newArrayList(if (true) new Double('-20') else new Integer('20'), new Integer('29'), new Double('29'))",
 					"ArrayList<Number & Comparable<?> & Constable & ConstantDesc>");
 		} else {
@@ -2484,7 +2485,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testVarArgs_06() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo("java::util::Arrays::asList(1, 3d, '4')", "List<Comparable<?> & Constable & ConstantDesc & Serializable>");
 		} else {
 			resolvesTo("java::util::Arrays::asList(1, 3d, '4')", "List<Comparable<?> & Serializable>");
@@ -2552,7 +2553,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testMemberFeatureCall_05() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 		} else {
 		}
 		resolvesTo("''.^class.superclass", "Class<?>");
@@ -2560,7 +2561,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testFeatureCall_04() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo("new testdata.ClassWithVarArgs().toList('', 1)", "List<Comparable<?> & Constable & ConstantDesc & Serializable>");
 		} else {
 			resolvesTo("new testdata.ClassWithVarArgs().toList('', 1)", "List<Comparable<?> & Serializable>");
@@ -2569,7 +2570,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testFeatureCall_05() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo("new testdata.ClassWithVarArgs().toNumberList()", "List<Number>");
 			resolvesTo("new testdata.ClassWithVarArgs().toNumberList(0)", "List<Integer>");
 			resolvesTo("new testdata.ClassWithVarArgs().toNumberList(0, 1)", "List<Integer>");
@@ -3916,7 +3917,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testDeferredTypeArgumentResolution_018() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo(
 				"{\n" +
 				"val list = newArrayList\n" +
@@ -4467,7 +4468,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testDeferredTypeArgumentResolution_064() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo(
 					"{\n" +
 				"val list = newArrayList\n" +
@@ -4695,7 +4696,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testDeferredTypeArgumentResolution_084() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo(
 				"{\n" +
 				"val list = new java.util.ArrayList\n" +
@@ -5254,7 +5255,7 @@ public abstract class AbstractTypeResolverTest<Reference extends Object> extends
 
 	@Test
 	public void testDeferredTypeArgumentResolution_130() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			resolvesTo(
 					"{\n" +
 				"val list = new java.util.ArrayList\n" +

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/InvokedResolvedOperationTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/InvokedResolvedOperationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2020 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,6 +8,7 @@
  */
 package org.eclipse.xtext.xbase.tests.typesystem;
 
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.XAbstractFeatureCall;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.tests.AbstractXbaseTestCase;
@@ -100,8 +101,7 @@ public class InvokedResolvedOperationTest extends AbstractXbaseTestCase {
 	@Test
 	public void testTypeArguments_02() throws Exception {
 		InvokedResolvedOperation operation = toOperation("newArrayList(1, 1d)");
-		boolean _isJava12OrLater = AbstractXbaseTestCase.isJava12OrLater();
-		if (_isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			Assert.assertEquals("ArrayList<Number & Comparable<?> & Constable & ConstantDesc>",
 					operation.getResolvedReturnType().getSimpleName());
 			Assert.assertEquals("Number & Comparable<?> & Constable & ConstantDesc",

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typing/XbaseTypeProviderTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typing/XbaseTypeProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -13,6 +13,7 @@ import java.math.BigInteger;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.XBlockExpression;
 import org.eclipse.xtext.xbase.XClosure;
 import org.eclipse.xtext.xbase.XExpression;
@@ -102,7 +103,7 @@ public class XbaseTypeProviderTest extends AbstractXbaseTestCase {
 	}
 	
 	@Test public void testIfExpression_02() throws Exception {
-		if (isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			assertResolvedType("java.lang.AbstractStringBuilder & java.io.Serializable & java.lang.Comparable<? extends java.lang.Object>", "if (true) new StringBuilder() else new StringBuffer()");
 		} else {
 			assertResolvedType("java.lang.AbstractStringBuilder & java.io.Serializable", "if (true) new StringBuilder() else new StringBuffer()");
@@ -135,7 +136,7 @@ public class XbaseTypeProviderTest extends AbstractXbaseTestCase {
 //		assertEquals("java.lang.Object", toString(typeProvider.getType(expression.getSwitch())));
 //		assertEquals("java.lang.String", toString(typeProvider.getType(expression.getCases().get(0).getThen())));
 //		assertEquals("java.lang.StringBuffer", toString(typeProvider.getType(expression.getCases().get(1).getThen())));
-		if (isJava11OrLater()) {
+		if (JavaRuntimeVersion.isJava11OrLater()) {
 			assertEquals("java.io.Serializable & java.lang.Comparable<? extends java.lang.Object> & java.lang.CharSequence", toString(getType(expression)));
 		} else{
 			assertEquals("java.io.Serializable & java.lang.CharSequence", toString(getType(expression)));
@@ -303,7 +304,7 @@ public class XbaseTypeProviderTest extends AbstractXbaseTestCase {
 	}
 
 	@Test public void testListLiteral_5() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			assertResolvedType("java.util.List<? extends java.lang.Number & java.lang.Comparable<? extends java.lang.Object> & java.lang.constant.Constable & java.lang.constant.ConstantDesc>", "#[1,2.0,3]");
 		} else {
 			assertResolvedType("java.util.List<? extends java.lang.Number & java.lang.Comparable<? extends java.lang.Object>>", "#[1,2.0,3]");
@@ -331,7 +332,7 @@ public class XbaseTypeProviderTest extends AbstractXbaseTestCase {
 	}
 
 	@Test public void testSetLiteral_5() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			assertResolvedType("java.util.Set<? extends java.lang.Number & java.lang.Comparable<? extends java.lang.Object> & java.lang.constant.Constable & java.lang.constant.ConstantDesc>", "#{1,2.0,3}");
 		} else {
 			assertResolvedType("java.util.Set<? extends java.lang.Number & java.lang.Comparable<? extends java.lang.Object>>", "#{1,2.0,3}");
@@ -375,7 +376,7 @@ public class XbaseTypeProviderTest extends AbstractXbaseTestCase {
 	}
 	
 	@Test public void testFeatureCall_04() throws Exception {
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			assertResolvedType("java.util.List<java.lang.Comparable<? extends java.lang.Object> & java.lang.constant.Constable & java.lang.constant.ConstantDesc & java.io.Serializable>", "new testdata.ClassWithVarArgs().toList('', 1)");
 		} else {
 			assertResolvedType("java.util.List<java.lang.Comparable<? extends java.lang.Object> & java.io.Serializable>", "new testdata.ClassWithVarArgs().toList('', 1)");
@@ -387,7 +388,7 @@ public class XbaseTypeProviderTest extends AbstractXbaseTestCase {
 		assertResolvedType("java.util.List<java.lang.Number>", "new testdata.ClassWithVarArgs().toNumberList()");
 		assertResolvedType("java.util.List<java.lang.Integer>", "new testdata.ClassWithVarArgs().toNumberList(0)");
 		assertResolvedType("java.util.List<java.lang.Integer>", "new testdata.ClassWithVarArgs().toNumberList(0, 1)");
-		if (isJava12OrLater()) {
+		if (JavaRuntimeVersion.isJava12OrLater()) {
 			assertResolvedType("java.util.List<java.lang.Number & java.lang.Comparable<? extends java.lang.Object> & java.lang.constant.Constable & java.lang.constant.ConstantDesc>", "new testdata.ClassWithVarArgs().toNumberList(new Integer(0), new Integer(0).doubleValue)");
 		} else {
 			assertResolvedType("java.util.List<java.lang.Number & java.lang.Comparable<? extends java.lang.Object>>", "new testdata.ClassWithVarArgs().toNumberList(new Integer(0), new Integer(0).doubleValue)");


### PR DESCRIPTION
[eclipse/xtext#1452] add common JavaRuntimeVersion utility to avoid code duplication between modules

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>