### PR TITLE
[eclipse/xtext#2019] workaround for grgit transitive jgit dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,13 @@ buildscript {
 	repositories.mavenCentral()
 	dependencies {
 		classpath "org.xtext:xtext-gradle-plugin:$versions.xtext_gradle_plugin"
+		constraints {
+			classpath("org.eclipse.jgit:org.eclipse.jgit") {
+				version {
+					strictly "[5.13, 6.0["
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
[eclipse/xtext#2019] workaround for grgit transitive jgit dependency
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>