### PR TITLE
[eclipse/xtext-xtend#1301] fix name clashes with anony. inner classes

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/XbaseCompiler.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/XbaseCompiler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2022 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -1912,7 +1912,7 @@ public class XbaseCompiler extends FeatureCallCompiler {
 		appendable.append(parameterType);
 		appendable.append(" ");
 		final String proposedParamName = makeJavaIdentifier(closureParam.getName());
-		String name = appendable.declareVariable(closureParam, proposedParamName);
+		String name = appendable.declareUniqueNameVariable(closureParam, proposedParamName);
 		appendable.append(name);
 	}
 	
@@ -1921,7 +1921,7 @@ public class XbaseCompiler extends FeatureCallCompiler {
 		appendable.append(parameterType);
 		appendable.append("... ");
 		final String proposedParamName = makeJavaIdentifier(closureParam.getName());
-		String name = appendable.declareVariable(closureParam, proposedParamName);
+		String name = appendable.declareUniqueNameVariable(closureParam, proposedParamName);
 		appendable.append(name);
 	}
 


### PR DESCRIPTION
[eclipse/xtext-xtend#1301] fix name clashes with anony. inner classes