### PR TITLE
[#805] Fixed accidentally broken semantic of failOnValidationError

### DIFF
--- a/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/StandaloneBuilder.java
+++ b/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/StandaloneBuilder.java
@@ -268,17 +268,17 @@ public class StandaloneBuilder {
 
 						// TODO adjust to handle validations that need an up-to-date index
 						hasValidationErrors = validate(resource) || hasValidationErrors;
-						if (failOnValidationError && hasValidationErrors) {
-							if (incremental) {
-								// since we didn't generate anything yet, we don't want to persist the builder state
-								builderState.processIssues(issueHandler);
-							}
-							return false;
-						}
 						clusterIndex++;
 						if (!strategy.continueProcessing(resourceSet, null, clusterIndex)) {
 							canContinue = false;
 						}
+					}
+					if (failOnValidationError && hasValidationErrors) {
+						if (incremental) {
+							// since we didn't generate anything yet, we don't want to persist the builder state
+							builderState.processIssues(issueHandler);
+						}
+						return false;
 					}
 					generate(resources);
 					if (!canContinue) {


### PR DESCRIPTION
The StandaloneBuilder is supposed to validate all resources and fail only afterwards (before generation).

The behavior is not consistent with clustering enabled, but it restores the previous state.

See #805 

Signed-off-by: Sebastian Zarnekow <sebastian.zarnekow@gmail.com>