### PR TITLE
[#805] Incremental compilation: Use fine grained hash for class files

### DIFF
--- a/org.eclipse.xtext.builder.standalone.tests/src/org/eclipse/xtext/builder/standalone/TestEclipseCompiler.java
+++ b/org.eclipse.xtext.builder.standalone.tests/src/org/eclipse/xtext/builder/standalone/TestEclipseCompiler.java
@@ -44,7 +44,7 @@ public class TestEclipseCompiler {
 	static final String DOES_NOT_EXISTS = "src/test/resources/test";
 	IJavaCompiler compiler;
 	File outputClassDirectory;
-	private static Injector injector;
+	static Injector injector;
 
 	@BeforeClass
 	public static void setUpOnce() {
@@ -53,11 +53,16 @@ public class TestEclipseCompiler {
 
 	@Before
 	public void setUp() throws IOException {
-		compiler = injector.getInstance(IJavaCompiler.class);
-		compiler.getConfiguration().setVerbose(true);
-		compiler.getConfiguration().setSourceLevel("8");
-		compiler.getConfiguration().setTargetLevel("8");
+		compiler = newCompiler();
 		outputClassDirectory = new File("target/temp");
+	}
+	
+	protected IJavaCompiler newCompiler() {
+		IJavaCompiler result = injector.getInstance(IJavaCompiler.class);
+		result.getConfiguration().setVerbose(true);
+		result.getConfiguration().setSourceLevel("8");
+		result.getConfiguration().setTargetLevel("8");
+		return result;
 	}
 
 	@After
@@ -106,7 +111,11 @@ public class TestEclipseCompiler {
 	}
 
 	Collection<URI> collectOutputFiles() {
-		return new PathTraverser().resolvePathes(Lists.newArrayList(outputClassDirectory.getAbsolutePath()),
+		return collectOutputFiles(outputClassDirectory);
+	}
+
+	protected Collection<URI> collectOutputFiles(File dir) {
+		return new PathTraverser().resolvePathes(Lists.newArrayList(dir.getAbsolutePath()),
 				new ClassFileFilter()).values();
 	}
 

--- a/org.eclipse.xtext.builder.standalone.tests/test-data/ec-test/test-class3/com/acme/Tweety.java
+++ b/org.eclipse.xtext.builder.standalone.tests/test-data/ec-test/test-class3/com/acme/Tweety.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Sebastian Zarnekow and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.acme;
+
+public class Tweety extends LoonyToon {
+
+	void chirp() {}
+	
+}

--- a/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/StandaloneBuilderFileCallback.java
+++ b/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/StandaloneBuilderFileCallback.java
@@ -51,7 +51,7 @@ public class StandaloneBuilderFileCallback implements IFileCallback {
 		if (!generatedFiles.isEmpty()) {
 			inputToGenFiles.put(resourceURI, generatedFiles.toArray(new IPath[0]));
 			for(IPath generatedFile: generatedFiles) {
-				BinaryFileHashing.processFile(generatedFile.toFile(), genFiles);
+				BinaryFileHashing.processFile(generatedFile.toFile(), genFiles::put);
 				genFileToInput.put(generatedFile, resourceURI);
 			}
 		}

--- a/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/incremental/ClasspathEntryHash.java
+++ b/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/incremental/ClasspathEntryHash.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Sebastian Zarnekow and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.builder.standalone.incremental;
+
+/**
+ * Abstract representation of a binary hashed class-path entry.
+ * 
+ * The hashing strategy in itself is not defined. It is guaranteed though
+ * that signature changes lead to changes in the hash that is produced for a 
+ * class-path entry. The inverse is not guaranteed though: Different hashes
+ * do not necessarily imply that the signatures did in fact change.  
+ * 
+ * @see CoarseGrainedEntryHash
+ * @see FineGrainedEntryHash
+ * @see ClasspathEntryHashVisitor
+ */
+public interface ClasspathEntryHash {
+	
+	void accept(ClasspathEntryHashVisitor visitor);
+	
+}

--- a/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/incremental/ClasspathEntryHashVisitor.java
+++ b/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/incremental/ClasspathEntryHashVisitor.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Sebastian Zarnekow and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.builder.standalone.incremental;
+
+import org.eclipse.core.runtime.IPath;
+
+import com.google.common.annotations.Beta;
+import com.google.common.hash.HashCode;
+
+/**
+ * Visitor over entry hashes. It is assumed that a {@link CoarseGrainedEntryHash} was made
+ * for an archive and directories are hashed {@link FineGrainedEntryHash on a per class basis}.
+ */
+@Beta
+public interface ClasspathEntryHashVisitor {
+	default void visitArchive(HashCode archiveHash) {}
+
+	default void visitClassFile(IPath fqn, HashCode classHash) {}
+}

--- a/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/incremental/ClasspathInfos.java
+++ b/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/incremental/ClasspathInfos.java
@@ -8,80 +8,68 @@
  *******************************************************************************/
 package org.eclipse.xtext.builder.standalone.incremental;
 
-import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.log4j.Logger;
 import org.eclipse.core.runtime.IPath;
 
-import com.google.common.hash.Funnels;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.HashCode;
-import com.google.common.hash.Hasher;
-import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import com.google.inject.Singleton;
 
 /**
+ * @see BinaryFileHashing
  * @author Sebastian Zarnekow - Initial contribution and API
  */
 @Singleton
 public class ClasspathInfos {
-	
-	private static final Logger logger = Logger.getLogger(ClasspathInfos.class);
-	
-	private static final int _16_KB = 16384;
-	
-	private ConcurrentHashMap<IPath, HashCode> hashes = new ConcurrentHashMap<>();
-	
-	public byte[] hashClassesOrJar(IPath path) {
-		return hashes.computeIfAbsent(path, any->{
-			if ("jar".equalsIgnoreCase(path.getFileExtension())) {
-				List<String> segments = Arrays.asList(path.segments());
+
+	private ConcurrentHashMap<IPath, ClasspathEntryHash> classpathEntries = new ConcurrentHashMap<>();
+
+	public ClasspathEntryHash hashClassesOrJar(IPath classpathEntry) {
+		return classpathEntries.computeIfAbsent(classpathEntry, any -> {
+			File classpathEntryAsFile = classpathEntry.toFile();
+			if ("jar".equalsIgnoreCase(classpathEntry.getFileExtension()) && classpathEntryAsFile.isFile()) {
+				List<String> segments = Arrays.asList(classpathEntry.segments());
 				if (segments.contains(".gradle")) {
 					String maybeHash = segments.get(segments.size() - 2);
 					if (maybeHash.length() >= 36) {
-						return BinaryFileHashing.hashFunction().hashString(maybeHash, StandardCharsets.ISO_8859_1);
+						HashCode hash = BinaryFileHashing.hashFunction().hashString(maybeHash, StandardCharsets.ISO_8859_1);
+						BinaryFileHashing.LOG.trace("Hashed file " + classpathEntryAsFile.getName() + " to " + hash);
+						return new CoarseGrainedEntryHash(hash);
 					}
 				}
-				File mavenSha1 = path.addFileExtension("sha1").toFile();
+				File mavenSha1 = classpathEntry.addFileExtension("sha1").toFile();
 				if (mavenSha1.isFile()) {
-					try {
-						byte[] bytes = java.nio.file.Files.readAllBytes(mavenSha1.toPath());
-						return BinaryFileHashing.hashFunction().hashBytes(bytes);
-					} catch (IOException e) {
-						logger.debug(e.getMessage(), e);
+					return new CoarseGrainedEntryHash(BinaryFileHashing.processFile(mavenSha1));
+				}
+				return new CoarseGrainedEntryHash(BinaryFileHashing.processFile(classpathEntryAsFile));
+			}
+			Map<IPath, HashCode> classHashes = new HashMap<>();
+			Files.fileTraverser().breadthFirst(classpathEntryAsFile).forEach(file -> {
+				if (file.isFile()) {
+					String fileName = file.getName().toLowerCase();
+					if (fileName.endsWith(".class")) {
+						BinaryFileHashing.processFile(file, (path, hash)->{
+							IPath fqn = path.makeRelativeTo(classpathEntry).removeFileExtension();
+							classHashes.put(fqn, hash);
+						});
 					}
 				}
-			} 
-			Hasher hasher = BinaryFileHashing.hashFunction().newHasher();
-			try (OutputStream hasherAsStream = Funnels.asOutputStream(hasher)) {
-				Files.fileTraverser().breadthFirst(path.toFile()).forEach(file -> {
-					if (file.isFile()) {
-						String fileName = file.getName().toLowerCase();
-						if (fileName.endsWith(".class") || fileName.endsWith(".jar")) {
-							try (InputStream in = new BufferedInputStream(new FileInputStream(file), _16_KB)) {
-								ByteStreams.copy(in, hasherAsStream);
-							} catch (IOException e) {
-								hasher.putBoolean(false);
-							}
-						}
-					}
-				});
-			} catch(IOException e) {
-				throw new RuntimeException(e);
-			}
-			return hasher.hash();
-			
-			
-		}).asBytes();
+			});
+			return new FineGrainedEntryHash(classHashes);
+		});
 	}
-	
+
+	@VisibleForTesting
+	public void clear() {
+		classpathEntries.clear();
+	}
+
 }

--- a/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/incremental/CoarseGrainedEntryHash.java
+++ b/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/incremental/CoarseGrainedEntryHash.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Sebastian Zarnekow and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.builder.standalone.incremental;
+
+import com.google.common.hash.HashCode;
+
+public class CoarseGrainedEntryHash implements ClasspathEntryHash {
+
+	private final HashCode hashCode;
+
+	public CoarseGrainedEntryHash(HashCode hashCode) {
+		this.hashCode = hashCode;
+	}
+
+	@Override
+	public void accept(ClasspathEntryHashVisitor visitor) {
+		visitor.visitArchive(hashCode);
+	}
+	
+	public byte[] asBytes() {
+		return hashCode.asBytes();
+	}
+
+}

--- a/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/incremental/FineGrainedEntryHash.java
+++ b/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/incremental/FineGrainedEntryHash.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Sebastian Zarnekow and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.builder.standalone.incremental;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.eclipse.core.runtime.IPath;
+
+import com.google.common.hash.HashCode;
+
+public class FineGrainedEntryHash implements ClasspathEntryHash {
+	private final Map<IPath, HashCode> classHashes;
+
+	public FineGrainedEntryHash(Map<IPath, HashCode> classHashes) {
+		this.classHashes = classHashes;
+	}
+
+	@Override
+	public void accept(ClasspathEntryHashVisitor visitor) {
+		classHashes.forEach(visitor::visitClassFile);
+	}
+
+	/**
+	 * The key in the map is a FQN represented as a path, e.g. {@code com/acme/Foo$Bar}.
+	 */
+	public Map<IPath, HashCode> classHashes() {
+		return Collections.unmodifiableMap(classHashes);
+	}
+
+}


### PR DESCRIPTION
This avoids a full build for the test sources if the production source code of a maven project is changed. Only the affected tests / models will need to be recompiled

[eclipse/xtext-extras#805]

Signed-off-by: Sebastian Zarnekow <sebastian.zarnekow@gmail.com>