### PR TITLE
[eclipse/xtext#2125] set minimum junit version to 4.13.2

### DIFF
--- a/org.eclipse.xtext.builder.standalone.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.builder.standalone.tests/META-INF/MANIFEST.MF
@@ -26,7 +26,7 @@ Export-Package: org.eclipse.xtext.builder.standalone,
  org.eclipse.xtext.builder.tests.services,
  org.eclipse.xtext.builder.tests.validation
 Import-Package: org.apache.log4j,
- org.junit;version="4.12.0",
- org.junit.runner;version="4.12.0",
- org.junit.runners;version="4.12.0"
+ org.junit;version="4.13.2",
+ org.junit.runner;version="4.13.2",
+ org.junit.runners;version="4.13.2"
 Automatic-Module-Name: org.eclipse.xtext.builder.standalone.tests

--- a/org.eclipse.xtext.common.types.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.common.types.tests/META-INF/MANIFEST.MF
@@ -46,9 +46,9 @@ Export-Package: org.eclipse.xtext.common.types,
  org.eclipse.xtext.common.types.xtext.ui.services
 Bundle-ActivationPolicy: lazy
 Import-Package: org.apache.log4j,
- org.junit;version="4.12.0",
- org.junit.rules;version="4.12.0",
- org.junit.runner;version="4.12.0",
- org.junit.runners;version="4.12.0",
- org.junit.runners.model;version="4.12.0"
+ org.junit;version="4.13.2",
+ org.junit.rules;version="4.13.2",
+ org.junit.runner;version="4.13.2",
+ org.junit.runners;version="4.13.2",
+ org.junit.runners.model;version="4.13.2"
 Automatic-Module-Name: org.eclipse.xtext.common.types.tests

--- a/org.eclipse.xtext.common.types.tests/META-INF/MANIFEST.MF_gen
+++ b/org.eclipse.xtext.common.types.tests/META-INF/MANIFEST.MF_gen
@@ -13,10 +13,10 @@ Require-Bundle: org.objectweb.asm;bundle-version="[9.4.0,9.5.0)";resolution:=opt
  org.eclipse.xtext.common.types.tests.ui,
  org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional
-Import-Package: org.junit.runner;version="4.5.0",
- org.junit.runner.manipulation;version="4.5.0",
- org.junit.runner.notification;version="4.5.0",
- org.junit.runners;version="4.5.0",
- org.junit.runners.model;version="4.5.0",
+Import-Package: org.junit.runner;version="4.13.2",
+ org.junit.runner.manipulation;version="4.13.2",
+ org.junit.runner.notification;version="4.13.2",
+ org.junit.runners;version="4.13.2",
+ org.junit.runners.model;version="4.13.2",
  org.hamcrest.core
 Bundle-Activator: org.eclipse.xtext.common.types.tests.AbstractActivator

--- a/org.eclipse.xtext.extras.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.extras.tests/META-INF/MANIFEST.MF
@@ -37,10 +37,10 @@ Require-Bundle: org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib
 Import-Package: org.apache.log4j,
- org.junit;version="4.12.0",
- org.junit.rules;version="4.12.0",
- org.junit.runner;version="4.12.0",
- org.junit.runners;version="4.12.0",
- org.junit.runners.model;version="4.12.0"
+ org.junit;version="4.13.2",
+ org.junit.rules;version="4.13.2",
+ org.junit.runner;version="4.13.2",
+ org.junit.runners;version="4.13.2",
+ org.junit.runners.model;version="4.13.2"
 Bundle-Vendor: Eclipse Xtext
 Automatic-Module-Name: org.eclipse.xtext.extras.tests

--- a/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/junit/Junit4Fragment.java
+++ b/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/junit/Junit4Fragment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2022 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -136,11 +136,11 @@ public class Junit4Fragment extends AbstractGeneratorFragment {
 	@Override
 	public String[] getImportedPackagesTests(Grammar grammar) {
 		return new String[] {
-				"org.junit.runner;version=\"4.5.0\"",
-				"org.junit.runner.manipulation;version=\"4.5.0\"",
-				"org.junit.runner.notification;version=\"4.5.0\"",
-				"org.junit.runners;version=\"4.5.0\"",
-				"org.junit.runners.model;version=\"4.5.0\"",
+				"org.junit.runner;version=\"4.13.2\"",
+				"org.junit.runner.manipulation;version=\"4.13.2\"",
+				"org.junit.runner.notification;version=\"4.13.2\"",
+				"org.junit.runners;version=\"4.13.2\"",
+				"org.junit.runners.model;version=\"4.13.2\"",
 				"org.hamcrest.core"
 		};
 	}

--- a/org.eclipse.xtext.java.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.java.tests/META-INF/MANIFEST.MF
@@ -19,11 +19,11 @@ Require-Bundle: org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  org.eclipse.xtext.java,
  org.eclipse.xtext.xbase.testdata
 Import-Package: org.apache.log4j,
- org.junit;version="4.12.0",
- org.junit.rules;version="4.12.0",
- org.junit.runner;version="4.12.0",
- org.junit.runners;version="4.12.0",
- org.junit.runners.model;version="4.12.0"
+ org.junit;version="4.13.2",
+ org.junit.rules;version="4.13.2",
+ org.junit.runner;version="4.13.2",
+ org.junit.runners;version="4.13.2",
+ org.junit.runners.model;version="4.13.2"
 Bundle-Vendor: Eclipse Xtext
 Automatic-Module-Name: org.eclipse.xtext.extras.tests
 Export-Package: org.eclipse.xtext.common.types.access.impl,

--- a/org.eclipse.xtext.purexbase.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.purexbase.tests/META-INF/MANIFEST.MF
@@ -19,12 +19,12 @@ Require-Bundle: org.eclipse.xtext.purexbase,
 Import-Package: org.apache.commons.logging,
  org.apache.log4j;version="1.2.19",
  org.hamcrest.core;version="1.1.0",
- org.junit;version="4.12.0",
- org.junit.runner;version="4.12.0",
- org.junit.runner.manipulation;version="4.12.0",
- org.junit.runner.notification;version="4.12.0",
- org.junit.runners;version="4.12.0",
- org.junit.runners.model;version="4.12.0"
+ org.junit;version="4.13.2",
+ org.junit.runner;version="4.13.2",
+ org.junit.runner.manipulation;version="4.13.2",
+ org.junit.runner.notification;version="4.13.2",
+ org.junit.runners;version="4.13.2",
+ org.junit.runners.model;version="4.13.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.xtext.purexbase.tests;x-internal=true,
  org.eclipse.xtext.purexbase.tests.data

--- a/org.eclipse.xtext.xbase.testdata/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.testdata/META-INF/MANIFEST.MF
@@ -29,4 +29,4 @@ Export-Package: .,
  testdata.a,
  testdata.b,
  testdata.ordersensitivity
-Import-Package: org.junit;version="4.12.0"
+Import-Package: org.junit;version="4.13.2"

--- a/org.eclipse.xtext.xbase.testing/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.testing/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase;visibility:=reexport,
  org.eclipse.jdt.core;bundle-version="3.13.102";visibility:=reexport,
- org.junit;bundle-version="4.12.0",
+ org.junit;bundle-version="4.13.2",
  org.eclipse.xtext.testing,
  org.eclipse.core.runtime;bundle-version="3.13.0"
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.xtext.xbase.testlanguages/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.testlanguages/META-INF/MANIFEST.MF
@@ -19,12 +19,12 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtext.testing
 Import-Package: org.apache.log4j,
  org.hamcrest.core,
- org.junit;version="4.12.0",
- org.junit.runner;version="4.12.0",
- org.junit.runner.manipulation;version="4.12.0",
- org.junit.runner.notification;version="4.12.0",
- org.junit.runners;version="4.12.0",
- org.junit.runners.model;version="4.12.0"
+ org.junit;version="4.13.2",
+ org.junit.runner;version="4.13.2",
+ org.junit.runner.manipulation;version="4.13.2",
+ org.junit.runner.notification;version="4.13.2",
+ org.junit.runners;version="4.13.2",
+ org.junit.runners.model;version="4.13.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.xtext.xbase.testlanguages,
  org.eclipse.xtext.xbase.testlanguages.bug462047,

--- a/org.eclipse.xtext.xbase.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.tests/META-INF/MANIFEST.MF
@@ -24,8 +24,8 @@ Export-Package: org.eclipse.xtext.xbase.tests,
  org.eclipse.xtext.xbase.tests.interpreter
 Import-Package: javax.inject;version="1.0.0",
  org.apache.log4j;version="1.2.19",
- org.junit;version="4.12.0",
- org.junit.rules;version="4.12.0",
- org.junit.runner;version="4.12.0",
- org.junit.runners;version="4.12.0"
+ org.junit;version="4.13.2",
+ org.junit.rules;version="4.13.2",
+ org.junit.runner;version="4.13.2",
+ org.junit.runners;version="4.13.2"
 Automatic-Module-Name: org.eclipse.xtext.xbase.tests


### PR DESCRIPTION
[eclipse/xtext#2125] set minimum junit version to 4.13.2